### PR TITLE
Add QA flag for input lat/lon with limited precision.

### DIFF
--- a/harmonize_wq/clean.py
+++ b/harmonize_wq/clean.py
@@ -78,6 +78,34 @@ def harmonize_depth(df_in, units='meter'):
     return df_out
 
 
+def check_precision(df_in, col, limit=3):
+    """
+    Note - be cautious of float type and real vs representable precision
+
+    Parameters
+    ----------
+    df_in : pandas.DataFrame
+        DataFrame with the required ResultDepthHeight columns.
+    unit_col : string
+        Desired column in df_in.
+    limit : integer, optional
+        Number of decimal places under which to detect. The default is 3.
+
+    Returns
+    -------
+    df_out : pandas.DataFrame
+        Dataframe with the quality assurance flag for precision
+
+    """
+    df_out = df_in.copy()
+    digits = [str(x).split('.')[1] for x in df_out[col]]  # List of precision
+    idx = [i for i, x in enumerate(digits) if int(x) < 3]  # List of failing
+    c_mask = df_out.index.isin(idx)  # Create mask using index
+    flag = '{}: Imprecise: lessthan{}decimaldigits'.format(col, limit)
+    df_out = harmonize.add_qa_flag(df_out, c_mask, flag)  # Assign flags
+    return df_out
+
+
 def methods_check(df_in, char_val, methods=None):
     """
     Check methods against list of accepted methods.

--- a/harmonize_wq/clean.py
+++ b/harmonize_wq/clean.py
@@ -98,9 +98,8 @@ def check_precision(df_in, col, limit=3):
 
     """
     df_out = df_in.copy()
-    digits = [str(x).split('.')[1] for x in df_out[col]]  # List of precision
-    idx = [i for i, x in enumerate(digits) if int(x) < 3]  # List of failing
-    c_mask = df_out.index.isin(idx)  # Create mask using index
+    # Create T/F mask based on len of everything after the decimal
+    c_mask = [len(str(x).split('.')[1]) < limit for x in df_out[col]]
     flag = '{}: Imprecise: lessthan{}decimaldigits'.format(col, limit)
     df_out = harmonize.add_qa_flag(df_out, c_mask, flag)  # Assign flags
     return df_out

--- a/harmonize_wq/location.py
+++ b/harmonize_wq/location.py
@@ -63,6 +63,16 @@ def infer_CRS(df_in,
     return df_out
 
 
+def check_precision(df_in, col, limit=3):
+    df_out = df_in.copy()
+    digits = [str(x).split('.')[1] for x in df_out[col]]
+    idx = [i for i, x in enumerate(digits) if int(x) < 3]
+    flag = '{}: Imprecise: lessthan3decimaldigits'.format(col)
+    c_mask = df_out.index.isin(idx)
+    df_out = harmonize.add_qa_flag(df_out, c_mask, flag)
+    return df_out
+
+
 def harmonize_locations(df_in, out_EPSG=4326,
                         intermediate_columns=False, **kwargs):
     """
@@ -105,6 +115,10 @@ def harmonize_locations(df_in, out_EPSG=4326,
 
     # Check columns are in df
     harmonize.df_checks(df2, [crs_col, lat_col, lon_col])
+
+    # Check location precision
+    df2 = check_precision(df2, lat_col)
+    df2 = check_precision(df2, lon_col)
 
     # Create tuple column
     df2['geom_orig'] = list(zip(df2[lon_col], df2[lat_col]))

--- a/harmonize_wq/location.py
+++ b/harmonize_wq/location.py
@@ -14,6 +14,7 @@ import dataretrieval.wqp as wqp
 from harmonize_wq import harmonize
 from harmonize_wq import domains
 from harmonize_wq import wrangle
+from harmonize_wq import clean
 
 
 def infer_CRS(df_in,
@@ -63,16 +64,6 @@ def infer_CRS(df_in,
     return df_out
 
 
-def check_precision(df_in, col, limit=3):
-    df_out = df_in.copy()
-    digits = [str(x).split('.')[1] for x in df_out[col]]
-    idx = [i for i, x in enumerate(digits) if int(x) < 3]
-    flag = '{}: Imprecise: lessthan3decimaldigits'.format(col)
-    c_mask = df_out.index.isin(idx)
-    df_out = harmonize.add_qa_flag(df_out, c_mask, flag)
-    return df_out
-
-
 def harmonize_locations(df_in, out_EPSG=4326,
                         intermediate_columns=False, **kwargs):
     """
@@ -117,8 +108,8 @@ def harmonize_locations(df_in, out_EPSG=4326,
     harmonize.df_checks(df2, [crs_col, lat_col, lon_col])
 
     # Check location precision
-    df2 = check_precision(df2, lat_col)
-    df2 = check_precision(df2, lon_col)
+    df2 = clean.check_precision(df2, lat_col)
+    df2 = clean.check_precision(df2, lon_col)
 
     # Create tuple column
     df2['geom_orig'] = list(zip(df2[lon_col], df2[lat_col]))

--- a/harmonize_wq/tests/test_harmonize_WQP.py
+++ b/harmonize_wq/tests/test_harmonize_WQP.py
@@ -190,6 +190,10 @@ def test_harmonize_locations():
     # Converted converted
     # Missing unit infered
     # Check QA_flag
+    # Check for precision flag
+    actual_imprecise = actual.iloc[3437]['QA_flag']
+    expected_imprecise = 'LatitudeMeasure: Imprecise: lessthan3decimaldigits'
+    assert actual_imprecise == expected_imprecise
 
 
 #@pytest.mark.skip(reason="no change")

--- a/harmonize_wq/tests/test_harmonize_WQP.py
+++ b/harmonize_wq/tests/test_harmonize_WQP.py
@@ -191,7 +191,7 @@ def test_harmonize_locations():
     # Missing unit infered
     # Check QA_flag
     # Check for precision flag
-    actual_imprecise = actual.iloc[3437]['QA_flag']
+    actual_imprecise = actual.iloc[302]['QA_flag']
     expected_imprecise = 'LatitudeMeasure: Imprecise: lessthan3decimaldigits'
     assert actual_imprecise == expected_imprecise
 


### PR DESCRIPTION
Closes #5. The default is for <3 decimal places to be flagged, this should be enough to catch locational information that gets misleading precision added during transformation between datums. Caution should be used if setting the limit to more decimal places as float64 is limited in it's representation. [Decimal](https://docs.python.org/3/library/decimal.html) may be a better way to deal with that in the future, but it would need to be used throughout, and implications of datatype stored in WQP, assigned by pandas, and compatibility with pint all to be considered.