### PR TITLE
Setup for automated code quality

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+import nox
+
+RUN_DEPS = ["geopandas", "pint", "dataretrieval"]
+
+FORMAT_DEPS = ["ruff >= 0.3.5"]
+TESTS_DEPS = ["pytest", "coverage"]
+
+ROOT_PATH = Path.cwd()
+SRC_PATH = ROOT_PATH / "harmonize_wq"
+TESTS_PATH = SRC_PATH / "tests"
+DOCS_PATH = ROOT_PATH / "docs"
+
+nox.options.reuse_venv = "yes"
+nox.options.sessions = ["format"]
+
+
+@nox.session
+def format(session):
+    """Apply coding style standards to code."""
+    session.install(*FORMAT_DEPS)
+    session.run("ruff", "format", SRC_PATH)
+    session.run("ruff", "check", "--fix", SRC_PATH)
+
+
+@nox.session
+def tests(session):
+    """Run tests and compute code coverage."""
+    session.install(*RUN_DEPS)
+    session.install(*TESTS_DEPS)
+    session.run("coverage", "run", "-m", "pytest", *session.posargs, TESTS_PATH)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,3 +35,20 @@ doc = ["sphinx"]
 "Homepage" = "https://github.com/USEPA/harmonize-wq"
 "Documentation" = "https://usepa.github.io/harmonize-wq/"
 "Bug Tracker" = "https://github.com/USEPA/harmonize-wq/issues"
+
+
+[tool.ruff.lint]
+select = [
+    "E",
+    "F",
+    "W",
+    "I"
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["harmonize_wq"]
+
+[tool.ruff.format]
+quote-style = "single"
+docstring-code-format = true
+


### PR DESCRIPTION
As discussed in https://github.com/pyOpenSci/software-submission/issues/157, here is a suggestion on how to automate code quality (but not limited to!) tasks.

The setup is simple, as we use only [ruff](https://docs.astral.sh/ruff/) to both format and lint the files.
I suggest using [nox](https://nox.thea.codes/en/stable/index.html) as the task runner. 

Running the formatter + linter is just as simple as

```shell
nox
```

for short, or 

```shell
nox -s format
```

for the long version.

Tests are also included:

```shell
nox -s tests
```


Now, for the configuration itself, I have added some entries to `pyproject.toml` with what, I think, is a good first setup for `harmonize_wq`.

There are things to discuss, so I'll keep this PR as a draft for now.