### PR TITLE
Update Python version matrix in test_r.yaml

### DIFF
--- a/.github/workflows/test_r.yaml
+++ b/.github/workflows/test_r.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10']
         
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Removed Python 3.11 from the workflow matrix.