### PR TITLE
Fix for Empty except

### DIFF
--- a/demos/Harmonize_CapeCod_Detailed.ipynb
+++ b/demos/Harmonize_CapeCod_Detailed.ipynb
@@ -54,10 +54,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:26:37.620694Z",
-     "iopub.status.busy": "2026-04-05T03:26:37.620513Z",
-     "iopub.status.idle": "2026-04-05T03:26:37.626894Z",
-     "shell.execute_reply": "2026-04-05T03:26:37.626310Z"
+     "iopub.execute_input": "2026-04-15T16:06:54.695568Z",
+     "iopub.status.busy": "2026-04-15T16:06:54.695382Z",
+     "iopub.status.idle": "2026-04-15T16:06:54.701351Z",
+     "shell.execute_reply": "2026-04-15T16:06:54.700857Z"
     }
    },
    "outputs": [],
@@ -75,10 +75,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:26:37.628896Z",
-     "iopub.status.busy": "2026-04-05T03:26:37.628693Z",
-     "iopub.status.idle": "2026-04-05T03:26:38.273510Z",
-     "shell.execute_reply": "2026-04-05T03:26:38.272827Z"
+     "iopub.execute_input": "2026-04-15T16:06:54.703209Z",
+     "iopub.status.busy": "2026-04-15T16:06:54.703005Z",
+     "iopub.status.idle": "2026-04-15T16:06:55.308429Z",
+     "shell.execute_reply": "2026-04-15T16:06:55.307883Z"
     }
    },
    "outputs": [],
@@ -103,10 +103,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:26:38.276033Z",
-     "iopub.status.busy": "2026-04-05T03:26:38.275772Z",
-     "iopub.status.idle": "2026-04-05T03:26:43.333030Z",
-     "shell.execute_reply": "2026-04-05T03:26:43.332225Z"
+     "iopub.execute_input": "2026-04-15T16:06:55.310973Z",
+     "iopub.status.busy": "2026-04-15T16:06:55.310684Z",
+     "iopub.status.idle": "2026-04-15T16:06:58.414442Z",
+     "shell.execute_reply": "2026-04-15T16:06:58.413746Z"
     }
    },
    "outputs": [
@@ -143,10 +143,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:26:43.343493Z",
-     "iopub.status.busy": "2026-04-05T03:26:43.343130Z",
-     "iopub.status.idle": "2026-04-05T03:26:43.347742Z",
-     "shell.execute_reply": "2026-04-05T03:26:43.347025Z"
+     "iopub.execute_input": "2026-04-15T16:06:58.427960Z",
+     "iopub.status.busy": "2026-04-15T16:06:58.427587Z",
+     "iopub.status.idle": "2026-04-15T16:06:58.431811Z",
+     "shell.execute_reply": "2026-04-15T16:06:58.431329Z"
     }
    },
    "outputs": [],
@@ -174,10 +174,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:26:43.349664Z",
-     "iopub.status.busy": "2026-04-05T03:26:43.349482Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.264335Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.263611Z"
+     "iopub.execute_input": "2026-04-15T16:06:58.433619Z",
+     "iopub.status.busy": "2026-04-15T16:06:58.433442Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.400602Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.400033Z"
     }
    },
    "outputs": [],
@@ -191,10 +191,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.267049Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.266849Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.271278Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.270710Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.403337Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.403090Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.407034Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.406444Z"
     }
    },
    "outputs": [
@@ -219,10 +219,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.273205Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.273023Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.291025Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.290217Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.408869Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.408675Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.424707Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.424136Z"
     }
    },
    "outputs": [
@@ -492,10 +492,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.293219Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.292996Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.299170Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.298458Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.426638Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.426426Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.431799Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.431204Z"
     }
    },
    "outputs": [
@@ -523,10 +523,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.301135Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.300943Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.633420Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.632583Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.433854Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.433647Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.756976Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.756293Z"
     }
    },
    "outputs": [
@@ -557,10 +557,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.635903Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.635678Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.675878Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.675010Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.759427Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.759217Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.800250Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.799518Z"
     }
    },
    "outputs": [],
@@ -574,10 +574,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.678371Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.678126Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.682544Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.681793Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.802705Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.802489Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.806509Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.805991Z"
     }
    },
    "outputs": [
@@ -602,10 +602,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.684558Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.684364Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.690809Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.690150Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.808386Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.808196Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.813954Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.813446Z"
     }
    },
    "outputs": [
@@ -635,17 +635,17 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.692772Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.692585Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.696780Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.696206Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.815748Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.815575Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.819375Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.818764Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<geopandas.array.GeometryDtype at 0x7fb5fe1a4460>"
+       "<geopandas.array.GeometryDtype at 0x7f8de6f8e040>"
       ]
      },
      "execution_count": 13,
@@ -663,10 +663,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.698696Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.698512Z",
-     "iopub.status.idle": "2026-04-05T03:27:08.704279Z",
-     "shell.execute_reply": "2026-04-05T03:27:08.703720Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.821364Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.821174Z",
+     "iopub.status.idle": "2026-04-15T16:07:19.826483Z",
+     "shell.execute_reply": "2026-04-15T16:07:19.825994Z"
     }
    },
    "outputs": [
@@ -696,10 +696,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:08.706267Z",
-     "iopub.status.busy": "2026-04-05T03:27:08.706076Z",
-     "iopub.status.idle": "2026-04-05T03:27:09.107929Z",
-     "shell.execute_reply": "2026-04-05T03:27:09.107188Z"
+     "iopub.execute_input": "2026-04-15T16:07:19.828306Z",
+     "iopub.status.busy": "2026-04-15T16:07:19.828099Z",
+     "iopub.status.idle": "2026-04-15T16:07:20.211405Z",
+     "shell.execute_reply": "2026-04-15T16:07:20.210735Z"
     }
    },
    "outputs": [
@@ -734,10 +734,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:09.109988Z",
-     "iopub.status.busy": "2026-04-05T03:27:09.109778Z",
-     "iopub.status.idle": "2026-04-05T03:27:09.784790Z",
-     "shell.execute_reply": "2026-04-05T03:27:09.784129Z"
+     "iopub.execute_input": "2026-04-15T16:07:20.213699Z",
+     "iopub.status.busy": "2026-04-15T16:07:20.213482Z",
+     "iopub.status.idle": "2026-04-15T16:07:20.883319Z",
+     "shell.execute_reply": "2026-04-15T16:07:20.882755Z"
     }
    },
    "outputs": [],
@@ -751,10 +751,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:09.787219Z",
-     "iopub.status.busy": "2026-04-05T03:27:09.787015Z",
-     "iopub.status.idle": "2026-04-05T03:27:09.945374Z",
-     "shell.execute_reply": "2026-04-05T03:27:09.944650Z"
+     "iopub.execute_input": "2026-04-15T16:07:20.885676Z",
+     "iopub.status.busy": "2026-04-15T16:07:20.885466Z",
+     "iopub.status.idle": "2026-04-15T16:07:21.034573Z",
+     "shell.execute_reply": "2026-04-15T16:07:21.033869Z"
     }
    },
    "outputs": [
@@ -789,10 +789,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:09.947646Z",
-     "iopub.status.busy": "2026-04-05T03:27:09.947444Z",
-     "iopub.status.idle": "2026-04-05T03:27:09.951746Z",
-     "shell.execute_reply": "2026-04-05T03:27:09.951170Z"
+     "iopub.execute_input": "2026-04-15T16:07:21.036627Z",
+     "iopub.status.busy": "2026-04-15T16:07:21.036414Z",
+     "iopub.status.idle": "2026-04-15T16:07:21.040284Z",
+     "shell.execute_reply": "2026-04-15T16:07:21.039772Z"
     }
    },
    "outputs": [
@@ -817,10 +817,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:09.953668Z",
-     "iopub.status.busy": "2026-04-05T03:27:09.953486Z",
-     "iopub.status.idle": "2026-04-05T03:27:09.956081Z",
-     "shell.execute_reply": "2026-04-05T03:27:09.955529Z"
+     "iopub.execute_input": "2026-04-15T16:07:21.042156Z",
+     "iopub.status.busy": "2026-04-15T16:07:21.041930Z",
+     "iopub.status.idle": "2026-04-15T16:07:21.044391Z",
+     "shell.execute_reply": "2026-04-15T16:07:21.043919Z"
     }
    },
    "outputs": [],
@@ -843,22 +843,13 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:27:09.958099Z",
-     "iopub.status.busy": "2026-04-05T03:27:09.957912Z",
-     "iopub.status.idle": "2026-04-05T03:41:27.700169Z",
-     "shell.execute_reply": "2026-04-05T03:41:27.699471Z"
+     "iopub.execute_input": "2026-04-15T16:07:21.046223Z",
+     "iopub.status.busy": "2026-04-15T16:07:21.046010Z",
+     "iopub.status.idle": "2026-04-15T16:21:57.376525Z",
+     "shell.execute_reply": "2026-04-15T16:21:57.375795Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:153: DtypeWarning: Columns (8,10,13,15,17,19,20,21,22,23,28,31,33,34,36,38,60,64,65,66,67,68,69,70,71,72) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now query for results\n",
     "query['dataProfile'] = 'narrowResult'\n",
@@ -870,10 +861,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:41:27.702549Z",
-     "iopub.status.busy": "2026-04-05T03:41:27.702299Z",
-     "iopub.status.idle": "2026-04-05T03:41:27.933276Z",
-     "shell.execute_reply": "2026-04-05T03:41:27.932530Z"
+     "iopub.execute_input": "2026-04-15T16:21:57.378835Z",
+     "iopub.status.busy": "2026-04-15T16:21:57.378614Z",
+     "iopub.status.idle": "2026-04-15T16:21:57.584990Z",
+     "shell.execute_reply": "2026-04-15T16:21:57.584335Z"
     }
    },
    "outputs": [
@@ -1004,7 +995,7 @@
        "      <td>EST</td>\n",
        "      <td>CRWA-ROB</td>\n",
        "      <td>STORET-591631481</td>\n",
-       "      <td>130809111433.0</td>\n",
+       "      <td>130809111433</td>\n",
        "      <td>NaN</td>\n",
        "      <td>...</td>\n",
        "      <td>NaN</td>\n",
@@ -1244,18 +1235,18 @@
        "575733                    NaN                            NaN   \n",
        "575734                    NaN                            NaN   \n",
        "\n",
-       "       MonitoringLocationIdentifier   ResultIdentifier  DataLoggerLine  \\\n",
-       "0                   BRC-C-02-02-020  STORET-1039097035             NaN   \n",
-       "1                      OARS-CND-161   STORET-838568413             NaN   \n",
-       "2                      OARS-SUD-064   STORET-838568309             NaN   \n",
-       "3                          CRWA-ROB   STORET-591631481  130809111433.0   \n",
-       "4                         WTGHA-M41  STORET-1041401688             NaN   \n",
-       "...                             ...                ...             ...   \n",
-       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866             NaN   \n",
-       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862             NaN   \n",
-       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863             NaN   \n",
-       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462             NaN   \n",
-       "575734     11NPSWRD_WQX-CACO_SLOUGH   STORET-740745800             NaN   \n",
+       "       MonitoringLocationIdentifier   ResultIdentifier DataLoggerLine  \\\n",
+       "0                   BRC-C-02-02-020  STORET-1039097035            NaN   \n",
+       "1                      OARS-CND-161   STORET-838568413            NaN   \n",
+       "2                      OARS-SUD-064   STORET-838568309            NaN   \n",
+       "3                          CRWA-ROB   STORET-591631481   130809111433   \n",
+       "4                         WTGHA-M41  STORET-1041401688            NaN   \n",
+       "...                             ...                ...            ...   \n",
+       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866            NaN   \n",
+       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862            NaN   \n",
+       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863            NaN   \n",
+       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462            NaN   \n",
+       "575734     11NPSWRD_WQX-CACO_SLOUGH   STORET-740745800            NaN   \n",
        "\n",
        "       ResultDetectionConditionText  ... AnalysisEndTime/TimeZoneCode  \\\n",
        "0                               NaN  ...                          NaN   \n",
@@ -1353,10 +1344,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:41:27.935550Z",
-     "iopub.status.busy": "2026-04-05T03:41:27.935339Z",
-     "iopub.status.idle": "2026-04-05T03:41:28.834473Z",
-     "shell.execute_reply": "2026-04-05T03:41:28.833660Z"
+     "iopub.execute_input": "2026-04-15T16:21:57.586971Z",
+     "iopub.status.busy": "2026-04-15T16:21:57.586780Z",
+     "iopub.status.idle": "2026-04-15T16:21:58.408606Z",
+     "shell.execute_reply": "2026-04-15T16:21:58.407938Z"
     }
    },
    "outputs": [
@@ -1410,10 +1401,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:41:28.836752Z",
-     "iopub.status.busy": "2026-04-05T03:41:28.836458Z",
-     "iopub.status.idle": "2026-04-05T03:41:28.839158Z",
-     "shell.execute_reply": "2026-04-05T03:41:28.838627Z"
+     "iopub.execute_input": "2026-04-15T16:21:58.410713Z",
+     "iopub.status.busy": "2026-04-15T16:21:58.410432Z",
+     "iopub.status.idle": "2026-04-15T16:21:58.412966Z",
+     "shell.execute_reply": "2026-04-15T16:21:58.412507Z"
     }
    },
    "outputs": [],
@@ -1435,10 +1426,10 @@
    "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:41:28.840958Z",
-     "iopub.status.busy": "2026-04-05T03:41:28.840784Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.086562Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.085794Z"
+     "iopub.execute_input": "2026-04-15T16:21:58.414761Z",
+     "iopub.status.busy": "2026-04-15T16:21:58.414587Z",
+     "iopub.status.idle": "2026-04-15T16:22:43.877751Z",
+     "shell.execute_reply": "2026-04-15T16:22:43.877178Z"
     },
     "scrolled": true
    },
@@ -1465,7 +1456,7 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: '%' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.25, 'meter')> <Quantity(4.25, 'meter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.25, 'meter')> <Quantity(4.25, 'meter')>\n",
       " <Quantity(3.5, 'meter')> ... <Quantity(17.0, 'meter')>\n",
       " <Quantity(16.0, 'meter')> <Quantity(7.8, 'meter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1521,10 +1512,10 @@
    "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.088671Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.088458Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.147663Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.147042Z"
+     "iopub.execute_input": "2026-04-15T16:22:43.879692Z",
+     "iopub.status.busy": "2026-04-15T16:22:43.879507Z",
+     "iopub.status.idle": "2026-04-15T16:22:43.937995Z",
+     "shell.execute_reply": "2026-04-15T16:22:43.937368Z"
     }
    },
    "outputs": [
@@ -1615,7 +1606,7 @@
        "    <tr>\n",
        "      <th>575730</th>\n",
        "      <td>11NPSWRD_WQX-CACO_DUCK_W</td>\n",
-       "      <td>10.0</td>\n",
+       "      <td>10</td>\n",
        "      <td>m</td>\n",
        "      <td>NaN</td>\n",
        "      <td>m</td>\n",
@@ -1624,7 +1615,7 @@
        "    <tr>\n",
        "      <th>575731</th>\n",
        "      <td>11NPSWRD_WQX-CACO_DUCK_W</td>\n",
-       "      <td>17.0</td>\n",
+       "      <td>17</td>\n",
        "      <td>m</td>\n",
        "      <td>NaN</td>\n",
        "      <td>m</td>\n",
@@ -1633,7 +1624,7 @@
        "    <tr>\n",
        "      <th>575732</th>\n",
        "      <td>11NPSWRD_WQX-CACO_DUCK_W</td>\n",
-       "      <td>16.0</td>\n",
+       "      <td>16</td>\n",
        "      <td>m</td>\n",
        "      <td>NaN</td>\n",
        "      <td>m</td>\n",
@@ -1670,9 +1661,9 @@
        "698               11113300-GRTKINSD               2.25   \n",
        "740               11113300-GRTKINSD               4.75   \n",
        "...                             ...                ...   \n",
-       "575730     11NPSWRD_WQX-CACO_DUCK_W               10.0   \n",
-       "575731     11NPSWRD_WQX-CACO_DUCK_W               17.0   \n",
-       "575732     11NPSWRD_WQX-CACO_DUCK_W               16.0   \n",
+       "575730     11NPSWRD_WQX-CACO_DUCK_W                 10   \n",
+       "575731     11NPSWRD_WQX-CACO_DUCK_W                 17   \n",
+       "575732     11NPSWRD_WQX-CACO_DUCK_W                 16   \n",
        "575733    11NPSWRD_WQX-CACO_GREAT_W                7.8   \n",
        "575734     11NPSWRD_WQX-CACO_SLOUGH                NaN   \n",
        "\n",
@@ -1722,10 +1713,10 @@
    "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.149569Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.149385Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.169158Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.168400Z"
+     "iopub.execute_input": "2026-04-15T16:22:43.940059Z",
+     "iopub.status.busy": "2026-04-15T16:22:43.939861Z",
+     "iopub.status.idle": "2026-04-15T16:22:43.958307Z",
+     "shell.execute_reply": "2026-04-15T16:22:43.957749Z"
     }
    },
    "outputs": [
@@ -1921,10 +1912,10 @@
    "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.171178Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.170987Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.186791Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.186041Z"
+     "iopub.execute_input": "2026-04-15T16:22:43.960194Z",
+     "iopub.status.busy": "2026-04-15T16:22:43.959973Z",
+     "iopub.status.idle": "2026-04-15T16:22:43.974713Z",
+     "shell.execute_reply": "2026-04-15T16:22:43.974122Z"
     }
    },
    "outputs": [
@@ -1949,10 +1940,10 @@
    "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.188779Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.188566Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.208114Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.207368Z"
+     "iopub.execute_input": "2026-04-15T16:22:43.976580Z",
+     "iopub.status.busy": "2026-04-15T16:22:43.976384Z",
+     "iopub.status.idle": "2026-04-15T16:22:43.994830Z",
+     "shell.execute_reply": "2026-04-15T16:22:43.994322Z"
     }
    },
    "outputs": [
@@ -2155,10 +2146,10 @@
    "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.210253Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.210038Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.227721Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.227006Z"
+     "iopub.execute_input": "2026-04-15T16:22:43.996623Z",
+     "iopub.status.busy": "2026-04-15T16:22:43.996442Z",
+     "iopub.status.idle": "2026-04-15T16:22:44.012501Z",
+     "shell.execute_reply": "2026-04-15T16:22:44.011951Z"
     }
    },
    "outputs": [
@@ -2292,10 +2283,10 @@
    "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.229654Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.229466Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.404458Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.403685Z"
+     "iopub.execute_input": "2026-04-15T16:22:44.014356Z",
+     "iopub.status.busy": "2026-04-15T16:22:44.014171Z",
+     "iopub.status.idle": "2026-04-15T16:22:44.174904Z",
+     "shell.execute_reply": "2026-04-15T16:22:44.174304Z"
     }
    },
    "outputs": [
@@ -2339,10 +2330,10 @@
    "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.406451Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.406227Z",
-     "iopub.status.idle": "2026-04-05T03:42:18.607801Z",
-     "shell.execute_reply": "2026-04-05T03:42:18.607072Z"
+     "iopub.execute_input": "2026-04-15T16:22:44.176839Z",
+     "iopub.status.busy": "2026-04-15T16:22:44.176657Z",
+     "iopub.status.idle": "2026-04-15T16:22:44.358140Z",
+     "shell.execute_reply": "2026-04-15T16:22:44.357541Z"
     }
    },
    "outputs": [
@@ -2392,10 +2383,10 @@
    "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:18.610069Z",
-     "iopub.status.busy": "2026-04-05T03:42:18.609823Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.590544Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.589791Z"
+     "iopub.execute_input": "2026-04-15T16:22:44.360358Z",
+     "iopub.status.busy": "2026-04-15T16:22:44.360161Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.042386Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.041732Z"
     }
    },
    "outputs": [
@@ -2412,14 +2403,8 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(22.18, 'degree_Celsius')> <Quantity(23.01, 'degree_Celsius')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(22.18, 'degree_Celsius')> <Quantity(23.01, 'degree_Celsius')>\n",
       " <Quantity(17.39, 'degree_Celsius')> ... <Quantity(2.9, 'degree_Celsius')>\n",
       " <Quantity(1.5, 'degree_Celsius')> <Quantity(3.9, 'degree_Celsius')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -2466,10 +2451,10 @@
    "execution_count": 33,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.592627Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.592433Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.659985Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.659373Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.044321Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.044099Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.113673Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.113095Z"
     }
    },
    "outputs": [
@@ -2654,10 +2639,10 @@
    "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.661906Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.661718Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.697627Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.696862Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.115765Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.115559Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.153197Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.152594Z"
     }
    },
    "outputs": [
@@ -2748,7 +2733,7 @@
        "    <tr>\n",
        "      <th>562404</th>\n",
        "      <td>11NPSWRD_WQX-SAIR_DMF11_HS1</td>\n",
-       "      <td>56.0</td>\n",
+       "      <td>56</td>\n",
        "      <td>deg F</td>\n",
        "      <td>NaN</td>\n",
        "      <td>13.333333333333371 degree_Celsius</td>\n",
@@ -2757,7 +2742,7 @@
        "    <tr>\n",
        "      <th>562405</th>\n",
        "      <td>11NPSWRD_WQX-SAIR_DMF11_OS3</td>\n",
-       "      <td>62.0</td>\n",
+       "      <td>62</td>\n",
        "      <td>deg F</td>\n",
        "      <td>NaN</td>\n",
        "      <td>16.666666666666686 degree_Celsius</td>\n",
@@ -2766,7 +2751,7 @@
        "    <tr>\n",
        "      <th>562406</th>\n",
        "      <td>11NPSWRD_WQX-SAIR_DMF11_OS4</td>\n",
-       "      <td>61.0</td>\n",
+       "      <td>61</td>\n",
        "      <td>deg F</td>\n",
        "      <td>NaN</td>\n",
        "      <td>16.111111111111143 degree_Celsius</td>\n",
@@ -2775,7 +2760,7 @@
        "    <tr>\n",
        "      <th>562408</th>\n",
        "      <td>11NPSWRD_WQX-SAIR_DMF11_OS1</td>\n",
-       "      <td>59.0</td>\n",
+       "      <td>59</td>\n",
        "      <td>deg F</td>\n",
        "      <td>NaN</td>\n",
        "      <td>15.000000000000057 degree_Celsius</td>\n",
@@ -2784,7 +2769,7 @@
        "    <tr>\n",
        "      <th>562413</th>\n",
        "      <td>11NPSWRD_WQX-SAIR_DMF11_S2</td>\n",
-       "      <td>43.0</td>\n",
+       "      <td>43</td>\n",
        "      <td>deg F</td>\n",
        "      <td>NaN</td>\n",
        "      <td>6.111111111111143 degree_Celsius</td>\n",
@@ -2803,11 +2788,11 @@
        "31705              11113300-HOODERD               59.9   \n",
        "32253              11113300-HOODERD                 56   \n",
        "...                             ...                ...   \n",
-       "562404  11NPSWRD_WQX-SAIR_DMF11_HS1               56.0   \n",
-       "562405  11NPSWRD_WQX-SAIR_DMF11_OS3               62.0   \n",
-       "562406  11NPSWRD_WQX-SAIR_DMF11_OS4               61.0   \n",
-       "562408  11NPSWRD_WQX-SAIR_DMF11_OS1               59.0   \n",
-       "562413   11NPSWRD_WQX-SAIR_DMF11_S2               43.0   \n",
+       "562404  11NPSWRD_WQX-SAIR_DMF11_HS1                 56   \n",
+       "562405  11NPSWRD_WQX-SAIR_DMF11_OS3                 62   \n",
+       "562406  11NPSWRD_WQX-SAIR_DMF11_OS4                 61   \n",
+       "562408  11NPSWRD_WQX-SAIR_DMF11_OS1                 59   \n",
+       "562413   11NPSWRD_WQX-SAIR_DMF11_S2                 43   \n",
        "\n",
        "       ResultMeasure/MeasureUnitCode QA_flag  \\\n",
        "12632                          deg F     NaN   \n",
@@ -2860,10 +2845,10 @@
    "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.699682Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.699474Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.725349Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.724609Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.155152Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.154914Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.180201Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.179643Z"
     }
    },
    "outputs": [
@@ -3079,10 +3064,10 @@
    "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.727492Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.727251Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.748280Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.747562Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.182008Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.181829Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.202949Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.202431Z"
     }
    },
    "outputs": [
@@ -3107,10 +3092,10 @@
    "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.750270Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.750062Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.778423Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.777662Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.204766Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.204555Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.232216Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.231680Z"
     }
    },
    "outputs": [
@@ -3306,10 +3291,10 @@
    "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.780376Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.780143Z",
-     "iopub.status.idle": "2026-04-05T03:42:22.888390Z",
-     "shell.execute_reply": "2026-04-05T03:42:22.887629Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.234044Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.233845Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.336304Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.335643Z"
     }
    },
    "outputs": [
@@ -3443,10 +3428,10 @@
    "execution_count": 39,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:22.890413Z",
-     "iopub.status.busy": "2026-04-05T03:42:22.890182Z",
-     "iopub.status.idle": "2026-04-05T03:42:23.147927Z",
-     "shell.execute_reply": "2026-04-05T03:42:23.147124Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.338336Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.338123Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.577439Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.576774Z"
     }
    },
    "outputs": [
@@ -3482,10 +3467,10 @@
    "execution_count": 40,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:23.150127Z",
-     "iopub.status.busy": "2026-04-05T03:42:23.149901Z",
-     "iopub.status.idle": "2026-04-05T03:42:23.511513Z",
-     "shell.execute_reply": "2026-04-05T03:42:23.510920Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.579410Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.579223Z",
+     "iopub.status.idle": "2026-04-15T16:22:48.918713Z",
+     "shell.execute_reply": "2026-04-15T16:22:48.918027Z"
     }
    },
    "outputs": [
@@ -3528,10 +3513,10 @@
    "execution_count": 41,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:23.513713Z",
-     "iopub.status.busy": "2026-04-05T03:42:23.513498Z",
-     "iopub.status.idle": "2026-04-05T03:42:43.527657Z",
-     "shell.execute_reply": "2026-04-05T03:42:43.526879Z"
+     "iopub.execute_input": "2026-04-15T16:22:48.920731Z",
+     "iopub.status.busy": "2026-04-15T16:22:48.920543Z",
+     "iopub.status.idle": "2026-04-15T16:23:04.998075Z",
+     "shell.execute_reply": "2026-04-15T16:23:04.997452Z"
     }
    },
    "outputs": [
@@ -3547,7 +3532,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.6, 'milligram / liter')> <Quantity(9.4, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.6, 'milligram / liter')> <Quantity(9.4, 'milligram / liter')>\n",
       " <Quantity(10.3, 'milligram / liter')> ...\n",
       " <Quantity(4.14, 'milligram / liter')>\n",
       " <Quantity(10.65, 'milligram / liter')>\n",
@@ -3573,10 +3558,10 @@
    "execution_count": 42,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:43.529752Z",
-     "iopub.status.busy": "2026-04-05T03:42:43.529544Z",
-     "iopub.status.idle": "2026-04-05T03:42:43.590680Z",
-     "shell.execute_reply": "2026-04-05T03:42:43.589895Z"
+     "iopub.execute_input": "2026-04-15T16:23:05.000298Z",
+     "iopub.status.busy": "2026-04-15T16:23:05.000090Z",
+     "iopub.status.idle": "2026-04-15T16:23:05.062018Z",
+     "shell.execute_reply": "2026-04-15T16:23:05.061392Z"
     }
    },
    "outputs": [
@@ -3749,10 +3734,10 @@
    "execution_count": 43,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:43.592612Z",
-     "iopub.status.busy": "2026-04-05T03:42:43.592425Z",
-     "iopub.status.idle": "2026-04-05T03:42:43.612864Z",
-     "shell.execute_reply": "2026-04-05T03:42:43.612072Z"
+     "iopub.execute_input": "2026-04-15T16:23:05.064245Z",
+     "iopub.status.busy": "2026-04-15T16:23:05.064003Z",
+     "iopub.status.idle": "2026-04-15T16:23:05.082197Z",
+     "shell.execute_reply": "2026-04-15T16:23:05.081649Z"
     }
    },
    "outputs": [
@@ -3929,10 +3914,10 @@
    "execution_count": 44,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:43.614965Z",
-     "iopub.status.busy": "2026-04-05T03:42:43.614757Z",
-     "iopub.status.idle": "2026-04-05T03:42:43.688700Z",
-     "shell.execute_reply": "2026-04-05T03:42:43.687915Z"
+     "iopub.execute_input": "2026-04-15T16:23:05.084092Z",
+     "iopub.status.busy": "2026-04-15T16:23:05.083909Z",
+     "iopub.status.idle": "2026-04-15T16:23:05.155135Z",
+     "shell.execute_reply": "2026-04-15T16:23:05.154454Z"
     }
    },
    "outputs": [
@@ -4066,10 +4051,10 @@
    "execution_count": 45,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:43.690760Z",
-     "iopub.status.busy": "2026-04-05T03:42:43.690557Z",
-     "iopub.status.idle": "2026-04-05T03:42:43.927726Z",
-     "shell.execute_reply": "2026-04-05T03:42:43.926970Z"
+     "iopub.execute_input": "2026-04-15T16:23:05.157046Z",
+     "iopub.status.busy": "2026-04-15T16:23:05.156859Z",
+     "iopub.status.idle": "2026-04-15T16:23:05.376746Z",
+     "shell.execute_reply": "2026-04-15T16:23:05.376155Z"
     }
    },
    "outputs": [
@@ -4105,10 +4090,10 @@
    "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:43.929896Z",
-     "iopub.status.busy": "2026-04-05T03:42:43.929686Z",
-     "iopub.status.idle": "2026-04-05T03:42:44.256571Z",
-     "shell.execute_reply": "2026-04-05T03:42:44.255763Z"
+     "iopub.execute_input": "2026-04-15T16:23:05.378761Z",
+     "iopub.status.busy": "2026-04-15T16:23:05.378568Z",
+     "iopub.status.idle": "2026-04-15T16:23:05.673637Z",
+     "shell.execute_reply": "2026-04-15T16:23:05.672952Z"
     }
    },
    "outputs": [
@@ -4151,10 +4136,10 @@
    "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:42:44.258860Z",
-     "iopub.status.busy": "2026-04-05T03:42:44.258639Z",
-     "iopub.status.idle": "2026-04-05T03:43:42.446099Z",
-     "shell.execute_reply": "2026-04-05T03:43:42.445326Z"
+     "iopub.execute_input": "2026-04-15T16:23:05.675642Z",
+     "iopub.status.busy": "2026-04-15T16:23:05.675452Z",
+     "iopub.status.idle": "2026-04-15T16:23:59.195341Z",
+     "shell.execute_reply": "2026-04-15T16:23:59.194670Z"
     }
    },
    "outputs": [
@@ -4171,14 +4156,8 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'mV' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.3, 'dimensionless')> <Quantity(8.16, 'dimensionless')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.3, 'dimensionless')> <Quantity(8.16, 'dimensionless')>\n",
       " <Quantity(7.99, 'dimensionless')> ... <Quantity(7.4, 'dimensionless')>\n",
       " <Quantity(7.5, 'dimensionless')> <Quantity(7.4, 'dimensionless')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -4231,10 +4210,10 @@
    "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:43:42.448189Z",
-     "iopub.status.busy": "2026-04-05T03:43:42.447999Z",
-     "iopub.status.idle": "2026-04-05T03:43:42.504482Z",
-     "shell.execute_reply": "2026-04-05T03:43:42.503790Z"
+     "iopub.execute_input": "2026-04-15T16:23:59.197470Z",
+     "iopub.status.busy": "2026-04-15T16:23:59.197269Z",
+     "iopub.status.idle": "2026-04-15T16:23:59.253855Z",
+     "shell.execute_reply": "2026-04-15T16:23:59.253219Z"
     }
    },
    "outputs": [
@@ -4406,10 +4385,10 @@
    "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:43:42.506674Z",
-     "iopub.status.busy": "2026-04-05T03:43:42.506480Z",
-     "iopub.status.idle": "2026-04-05T03:43:51.063581Z",
-     "shell.execute_reply": "2026-04-05T03:43:51.062886Z"
+     "iopub.execute_input": "2026-04-15T16:23:59.256098Z",
+     "iopub.status.busy": "2026-04-15T16:23:59.255886Z",
+     "iopub.status.idle": "2026-04-15T16:24:06.091436Z",
+     "shell.execute_reply": "2026-04-15T16:24:06.090788Z"
     }
    },
    "outputs": [
@@ -4441,7 +4420,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(30.33, 'Practical_Salinity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(30.33, 'Practical_Salinity_Units')>\n",
       " <Quantity(30.48, 'Practical_Salinity_Units')>\n",
       " <Quantity(33.3, 'Practical_Salinity_Units')> ...\n",
       " <Quantity(0.11, 'Practical_Salinity_Units')>\n",
@@ -4490,10 +4469,10 @@
    "execution_count": 50,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:43:51.065633Z",
-     "iopub.status.busy": "2026-04-05T03:43:51.065441Z",
-     "iopub.status.idle": "2026-04-05T03:43:51.122877Z",
-     "shell.execute_reply": "2026-04-05T03:43:51.122080Z"
+     "iopub.execute_input": "2026-04-15T16:24:06.093408Z",
+     "iopub.status.busy": "2026-04-15T16:24:06.093194Z",
+     "iopub.status.idle": "2026-04-15T16:24:06.150062Z",
+     "shell.execute_reply": "2026-04-15T16:24:06.149386Z"
     }
    },
    "outputs": [
@@ -4659,10 +4638,10 @@
    "execution_count": 51,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:43:51.125118Z",
-     "iopub.status.busy": "2026-04-05T03:43:51.124894Z",
-     "iopub.status.idle": "2026-04-05T03:43:55.413563Z",
-     "shell.execute_reply": "2026-04-05T03:43:55.412909Z"
+     "iopub.execute_input": "2026-04-15T16:24:06.151993Z",
+     "iopub.status.busy": "2026-04-15T16:24:06.151817Z",
+     "iopub.status.idle": "2026-04-15T16:24:09.846452Z",
+     "shell.execute_reply": "2026-04-15T16:24:09.845784Z"
     }
    },
    "outputs": [
@@ -4712,7 +4691,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.926976, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.926976, 'milligram / liter')>\n",
       " <Quantity(1.571196, 'milligram / liter')>\n",
       " <Quantity(0.816144, 'milligram / liter')> ...\n",
       " <Quantity(0.238, 'milligram / liter')>\n",
@@ -4775,10 +4754,10 @@
    "execution_count": 52,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:43:55.415529Z",
-     "iopub.status.busy": "2026-04-05T03:43:55.415303Z",
-     "iopub.status.idle": "2026-04-05T03:43:55.465341Z",
-     "shell.execute_reply": "2026-04-05T03:43:55.464659Z"
+     "iopub.execute_input": "2026-04-15T16:24:09.848579Z",
+     "iopub.status.busy": "2026-04-15T16:24:09.848388Z",
+     "iopub.status.idle": "2026-04-15T16:24:09.900009Z",
+     "shell.execute_reply": "2026-04-15T16:24:09.899295Z"
     }
    },
    "outputs": [
@@ -4957,10 +4936,10 @@
    "execution_count": 53,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:43:55.467462Z",
-     "iopub.status.busy": "2026-04-05T03:43:55.467242Z",
-     "iopub.status.idle": "2026-04-05T03:44:00.436552Z",
-     "shell.execute_reply": "2026-04-05T03:44:00.435839Z"
+     "iopub.execute_input": "2026-04-15T16:24:09.902040Z",
+     "iopub.status.busy": "2026-04-15T16:24:09.901842Z",
+     "iopub.status.idle": "2026-04-15T16:24:14.200170Z",
+     "shell.execute_reply": "2026-04-15T16:24:14.199485Z"
     }
    },
    "outputs": [
@@ -4977,8 +4956,14 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(590.0, 'microsiemens / centimeter')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(590.0, 'microsiemens / centimeter')>\n",
       " <Quantity(43500.0, 'microsiemens / centimeter')>\n",
       " <Quantity(349.0, 'microsiemens / centimeter')> ...\n",
       " <Quantity(465.6, 'microsiemens / centimeter')>\n",
@@ -5027,10 +5012,10 @@
    "execution_count": 54,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:44:00.438659Z",
-     "iopub.status.busy": "2026-04-05T03:44:00.438468Z",
-     "iopub.status.idle": "2026-04-05T03:44:00.489185Z",
-     "shell.execute_reply": "2026-04-05T03:44:00.488563Z"
+     "iopub.execute_input": "2026-04-15T16:24:14.202123Z",
+     "iopub.status.busy": "2026-04-15T16:24:14.201912Z",
+     "iopub.status.idle": "2026-04-15T16:24:14.252205Z",
+     "shell.execute_reply": "2026-04-15T16:24:14.251594Z"
     }
    },
    "outputs": [
@@ -5196,10 +5181,10 @@
    "execution_count": 55,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:44:00.491297Z",
-     "iopub.status.busy": "2026-04-05T03:44:00.491088Z",
-     "iopub.status.idle": "2026-04-05T03:44:06.291041Z",
-     "shell.execute_reply": "2026-04-05T03:44:06.290293Z"
+     "iopub.execute_input": "2026-04-15T16:24:14.254214Z",
+     "iopub.status.busy": "2026-04-15T16:24:14.253997Z",
+     "iopub.status.idle": "2026-04-15T16:24:19.424415Z",
+     "shell.execute_reply": "2026-04-15T16:24:19.423745Z"
     }
    },
    "outputs": [
@@ -5215,7 +5200,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/cm2' UNDEFINED UNIT for Chlorophyll\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/m3' UNDEFINED UNIT for Chlorophyll\n",
       "  warn(\"WARNING: \" + problem)\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ppb' UNDEFINED UNIT for Chlorophyll\n",
       "  warn(\"WARNING: \" + problem)\n"
@@ -5225,7 +5210,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/m3' UNDEFINED UNIT for Chlorophyll\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/cm2' UNDEFINED UNIT for Chlorophyll\n",
       "  warn(\"WARNING: \" + problem)\n"
      ]
     },
@@ -5233,7 +5218,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.004, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.004, 'milligram / liter')>\n",
       " <Quantity(0.0055, 'milligram / liter')>\n",
       " <Quantity(0.00948, 'milligram / liter')> ...\n",
       " <Quantity(0.0007, 'milligram / liter')>\n",
@@ -5282,10 +5267,10 @@
    "execution_count": 56,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:44:06.293046Z",
-     "iopub.status.busy": "2026-04-05T03:44:06.292843Z",
-     "iopub.status.idle": "2026-04-05T03:44:06.344512Z",
-     "shell.execute_reply": "2026-04-05T03:44:06.343726Z"
+     "iopub.execute_input": "2026-04-15T16:24:19.426411Z",
+     "iopub.status.busy": "2026-04-15T16:24:19.426220Z",
+     "iopub.status.idle": "2026-04-15T16:24:19.477651Z",
+     "shell.execute_reply": "2026-04-15T16:24:19.477046Z"
     }
    },
    "outputs": [
@@ -5464,10 +5449,10 @@
    "execution_count": 57,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:44:06.346736Z",
-     "iopub.status.busy": "2026-04-05T03:44:06.346527Z",
-     "iopub.status.idle": "2026-04-05T03:44:09.383381Z",
-     "shell.execute_reply": "2026-04-05T03:44:09.382657Z"
+     "iopub.execute_input": "2026-04-15T16:24:19.479657Z",
+     "iopub.status.busy": "2026-04-15T16:24:19.479469Z",
+     "iopub.status.idle": "2026-04-15T16:24:22.252572Z",
+     "shell.execute_reply": "2026-04-15T16:24:22.251953Z"
     }
    },
    "outputs": [
@@ -5484,14 +5469,8 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'umol/L * H2O' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.05, 'milligram / liter')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.05, 'milligram / liter')>\n",
       " <Quantity(7.57, 'milligram / liter')>\n",
       " <Quantity(3.5, 'milligram / liter')> ...\n",
       " <Quantity(4.1, 'milligram / liter')>\n",
@@ -5540,10 +5519,10 @@
    "execution_count": 58,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:44:09.385290Z",
-     "iopub.status.busy": "2026-04-05T03:44:09.385084Z",
-     "iopub.status.idle": "2026-04-05T03:44:09.435475Z",
-     "shell.execute_reply": "2026-04-05T03:44:09.434724Z"
+     "iopub.execute_input": "2026-04-15T16:24:22.254524Z",
+     "iopub.status.busy": "2026-04-15T16:24:22.254335Z",
+     "iopub.status.idle": "2026-04-15T16:24:22.303998Z",
+     "shell.execute_reply": "2026-04-15T16:24:22.303384Z"
     }
    },
    "outputs": [
@@ -5619,7 +5598,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575541</th>\n",
-       "      <td>5.0</td>\n",
+       "      <td>5</td>\n",
        "      <td>mg/L</td>\n",
        "      <td>NaN</td>\n",
        "      <td>5.0 milligram / liter</td>\n",
@@ -5633,7 +5612,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575636</th>\n",
-       "      <td>4.1</td>\n",
+       "      <td>4.10</td>\n",
        "      <td>mg/l</td>\n",
        "      <td>NaN</td>\n",
        "      <td>4.1 milligram / liter</td>\n",
@@ -5665,9 +5644,9 @@
        "3158                  3.8                          mg/L     NaN   \n",
        "4020                  3.7                          mg/L     NaN   \n",
        "...                   ...                           ...     ...   \n",
-       "575541                5.0                          mg/L     NaN   \n",
+       "575541                  5                          mg/L     NaN   \n",
        "575593               5.96                          mg/l     NaN   \n",
-       "575636                4.1                          mg/l     NaN   \n",
+       "575636               4.10                          mg/l     NaN   \n",
        "575642               7.79                          mg/l     NaN   \n",
        "575679               5.79                          mg/l     NaN   \n",
        "\n",
@@ -5709,10 +5688,10 @@
    "execution_count": 59,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:44:09.437617Z",
-     "iopub.status.busy": "2026-04-05T03:44:09.437430Z",
-     "iopub.status.idle": "2026-04-05T03:46:58.199168Z",
-     "shell.execute_reply": "2026-04-05T03:46:58.198439Z"
+     "iopub.execute_input": "2026-04-15T16:24:22.306160Z",
+     "iopub.status.busy": "2026-04-15T16:24:22.305942Z",
+     "iopub.status.idle": "2026-04-15T16:27:01.945410Z",
+     "shell.execute_reply": "2026-04-15T16:27:01.944741Z"
     }
    },
    "outputs": [
@@ -5744,7 +5723,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.6, 'Nephelometric_Turbidity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.6, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(1.0, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(4.2, 'Nephelometric_Turbidity_Units')> ...\n",
       " <Quantity(2.1, 'Nephelometric_Turbidity_Units')>\n",
@@ -5793,10 +5772,10 @@
    "execution_count": 60,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:46:58.201142Z",
-     "iopub.status.busy": "2026-04-05T03:46:58.200936Z",
-     "iopub.status.idle": "2026-04-05T03:46:58.254146Z",
-     "shell.execute_reply": "2026-04-05T03:46:58.253412Z"
+     "iopub.execute_input": "2026-04-15T16:27:01.947343Z",
+     "iopub.status.busy": "2026-04-15T16:27:01.947154Z",
+     "iopub.status.idle": "2026-04-15T16:27:01.999391Z",
+     "shell.execute_reply": "2026-04-15T16:27:01.998790Z"
     }
    },
    "outputs": [
@@ -5962,10 +5941,10 @@
    "execution_count": 61,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:46:58.256300Z",
-     "iopub.status.busy": "2026-04-05T03:46:58.256084Z",
-     "iopub.status.idle": "2026-04-05T03:46:59.885273Z",
-     "shell.execute_reply": "2026-04-05T03:46:59.884523Z"
+     "iopub.execute_input": "2026-04-15T16:27:02.001515Z",
+     "iopub.status.busy": "2026-04-15T16:27:02.001313Z",
+     "iopub.status.idle": "2026-04-15T16:27:03.503852Z",
+     "shell.execute_reply": "2026-04-15T16:27:03.503175Z"
     }
    },
    "outputs": [
@@ -5998,10 +5977,10 @@
    "execution_count": 62,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:46:59.887481Z",
-     "iopub.status.busy": "2026-04-05T03:46:59.887245Z",
-     "iopub.status.idle": "2026-04-05T03:46:59.932430Z",
-     "shell.execute_reply": "2026-04-05T03:46:59.931700Z"
+     "iopub.execute_input": "2026-04-15T16:27:03.505880Z",
+     "iopub.status.busy": "2026-04-15T16:27:03.505686Z",
+     "iopub.status.idle": "2026-04-15T16:27:03.550736Z",
+     "shell.execute_reply": "2026-04-15T16:27:03.550141Z"
     }
    },
    "outputs": [
@@ -6035,7 +6014,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>522648</th>\n",
-       "      <td>0.012</td>\n",
+       "      <td>0.0120</td>\n",
        "      <td>g</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -6056,7 +6035,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>522651</th>\n",
-       "      <td>0.001</td>\n",
+       "      <td>0.0010</td>\n",
        "      <td>g</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -6091,7 +6070,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>574922</th>\n",
-       "      <td>0.002</td>\n",
+       "      <td>0.0020</td>\n",
        "      <td>g</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -6117,15 +6096,15 @@
       ],
       "text/plain": [
        "       ResultMeasureValue ResultMeasure/MeasureUnitCode QA_flag  Sediment\n",
-       "522648              0.012                             g     NaN       NaN\n",
+       "522648             0.0120                             g     NaN       NaN\n",
        "522649             0.0037                             g     NaN       NaN\n",
        "522650             0.0048                             g     NaN       NaN\n",
-       "522651              0.001                             g     NaN       NaN\n",
+       "522651             0.0010                             g     NaN       NaN\n",
        "522652             0.0088                             g     NaN       NaN\n",
        "...                   ...                           ...     ...       ...\n",
        "574776             0.0051                             g     NaN       NaN\n",
        "574850             0.0025                             g     NaN       NaN\n",
-       "574922              0.002                             g     NaN       NaN\n",
+       "574922             0.0020                             g     NaN       NaN\n",
        "574961             0.0023                             g     NaN       NaN\n",
        "575007             0.0014                             g     NaN       NaN\n",
        "\n",
@@ -6161,10 +6140,10 @@
    "execution_count": 63,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:46:59.934597Z",
-     "iopub.status.busy": "2026-04-05T03:46:59.934407Z",
-     "iopub.status.idle": "2026-04-05T03:47:06.365574Z",
-     "shell.execute_reply": "2026-04-05T03:47:06.364858Z"
+     "iopub.execute_input": "2026-04-15T16:27:03.553086Z",
+     "iopub.status.busy": "2026-04-15T16:27:03.552839Z",
+     "iopub.status.idle": "2026-04-15T16:27:09.019899Z",
+     "shell.execute_reply": "2026-04-15T16:27:09.019324Z"
     }
    },
    "outputs": [
@@ -6185,7 +6164,13 @@
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/pandas/core/construction.py:627: UnitStrippedWarning: The unit of the quantity is stripped when downcasting to ndarray.\n",
       "  data = np.asarray(data)\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/pandas/core/construction.py:627: UnitStrippedWarning: The unit of the quantity is stripped when downcasting to ndarray.\n",
-      "  data = np.asarray(data)\n",
+      "  data = np.asarray(data)\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'umol/L * H2O' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
@@ -6194,7 +6179,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
       " <Quantity(0.024, 'milligram / liter')>\n",
       " <Quantity(0.05, 'milligram / liter')> ...\n",
       " <Quantity(0.008, 'milligram / liter')>\n",
@@ -6235,10 +6220,10 @@
    "execution_count": 64,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:06.368055Z",
-     "iopub.status.busy": "2026-04-05T03:47:06.367815Z",
-     "iopub.status.idle": "2026-04-05T03:47:06.404078Z",
-     "shell.execute_reply": "2026-04-05T03:47:06.403317Z"
+     "iopub.execute_input": "2026-04-15T16:27:09.022413Z",
+     "iopub.status.busy": "2026-04-15T16:27:09.022214Z",
+     "iopub.status.idle": "2026-04-15T16:27:09.058257Z",
+     "shell.execute_reply": "2026-04-15T16:27:09.057581Z"
     }
    },
    "outputs": [
@@ -6398,10 +6383,10 @@
    "execution_count": 65,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:06.406272Z",
-     "iopub.status.busy": "2026-04-05T03:47:06.406068Z",
-     "iopub.status.idle": "2026-04-05T03:47:06.439524Z",
-     "shell.execute_reply": "2026-04-05T03:47:06.438827Z"
+     "iopub.execute_input": "2026-04-15T16:27:09.060290Z",
+     "iopub.status.busy": "2026-04-15T16:27:09.060072Z",
+     "iopub.status.idle": "2026-04-15T16:27:09.092274Z",
+     "shell.execute_reply": "2026-04-15T16:27:09.091695Z"
     }
    },
    "outputs": [
@@ -6547,10 +6532,10 @@
    "execution_count": 66,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:06.441466Z",
-     "iopub.status.busy": "2026-04-05T03:47:06.441248Z",
-     "iopub.status.idle": "2026-04-05T03:47:06.474245Z",
-     "shell.execute_reply": "2026-04-05T03:47:06.473560Z"
+     "iopub.execute_input": "2026-04-15T16:27:09.094191Z",
+     "iopub.status.busy": "2026-04-15T16:27:09.093979Z",
+     "iopub.status.idle": "2026-04-15T16:27:09.125495Z",
+     "shell.execute_reply": "2026-04-15T16:27:09.124943Z"
     }
    },
    "outputs": [
@@ -6709,10 +6694,10 @@
    "execution_count": 67,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:06.476241Z",
-     "iopub.status.busy": "2026-04-05T03:47:06.476053Z",
-     "iopub.status.idle": "2026-04-05T03:47:06.507877Z",
-     "shell.execute_reply": "2026-04-05T03:47:06.507154Z"
+     "iopub.execute_input": "2026-04-15T16:27:09.127352Z",
+     "iopub.status.busy": "2026-04-15T16:27:09.127165Z",
+     "iopub.status.idle": "2026-04-15T16:27:09.157242Z",
+     "shell.execute_reply": "2026-04-15T16:27:09.156535Z"
     }
    },
    "outputs": [
@@ -6788,35 +6773,35 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>558715</th>\n",
-       "      <td>2600.0</td>\n",
+       "      <td>2600</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>558753</th>\n",
-       "      <td>2900.0</td>\n",
+       "      <td>2900</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>558820</th>\n",
-       "      <td>2500.0</td>\n",
+       "      <td>2500</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>558898</th>\n",
-       "      <td>2600.0</td>\n",
+       "      <td>2600</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>558907</th>\n",
-       "      <td>2200.0</td>\n",
+       "      <td>2200</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -6834,11 +6819,11 @@
        "56022             0.04356                          mg/L     NaN            NaN\n",
        "56151          0.03654875                          mg/L     NaN            NaN\n",
        "...                   ...                           ...     ...            ...\n",
-       "558715             2600.0                         mg/kg     NaN            NaN\n",
-       "558753             2900.0                         mg/kg     NaN            NaN\n",
-       "558820             2500.0                         mg/kg     NaN            NaN\n",
-       "558898             2600.0                         mg/kg     NaN            NaN\n",
-       "558907             2200.0                         mg/kg     NaN            NaN\n",
+       "558715               2600                         mg/kg     NaN            NaN\n",
+       "558753               2900                         mg/kg     NaN            NaN\n",
+       "558820               2500                         mg/kg     NaN            NaN\n",
+       "558898               2600                         mg/kg     NaN            NaN\n",
+       "558907               2200                         mg/kg     NaN            NaN\n",
        "\n",
        "[416 rows x 4 columns]"
       ]
@@ -6879,10 +6864,10 @@
    "execution_count": 68,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:06.509955Z",
-     "iopub.status.busy": "2026-04-05T03:47:06.509747Z",
-     "iopub.status.idle": "2026-04-05T03:47:10.099497Z",
-     "shell.execute_reply": "2026-04-05T03:47:10.098869Z"
+     "iopub.execute_input": "2026-04-15T16:27:09.159441Z",
+     "iopub.status.busy": "2026-04-15T16:27:09.159245Z",
+     "iopub.status.idle": "2026-04-15T16:27:12.365738Z",
+     "shell.execute_reply": "2026-04-15T16:27:12.365081Z"
     }
    },
    "outputs": [
@@ -6903,8 +6888,14 @@
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(140.0, 'Colony_Forming_Units / milliliter')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(140.0, 'Colony_Forming_Units / milliliter')>\n",
       " nan <Quantity(1.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
      ]
@@ -6949,10 +6940,10 @@
    "execution_count": 69,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:10.101498Z",
-     "iopub.status.busy": "2026-04-05T03:47:10.101267Z",
-     "iopub.status.idle": "2026-04-05T03:47:10.152095Z",
-     "shell.execute_reply": "2026-04-05T03:47:10.151401Z"
+     "iopub.execute_input": "2026-04-15T16:27:12.367705Z",
+     "iopub.status.busy": "2026-04-15T16:27:12.367508Z",
+     "iopub.status.idle": "2026-04-15T16:27:12.418200Z",
+     "shell.execute_reply": "2026-04-15T16:27:12.417554Z"
     }
    },
    "outputs": [
@@ -7028,35 +7019,35 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>571178</th>\n",
-       "      <td>440.0</td>\n",
+       "      <td>440</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>440.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>571192</th>\n",
-       "      <td>450.0</td>\n",
+       "      <td>450</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>450.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>571213</th>\n",
-       "      <td>140.0</td>\n",
+       "      <td>140</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>140.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>571419</th>\n",
-       "      <td>180.0</td>\n",
+       "      <td>180</td>\n",
        "      <td>#/100mL</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>571476</th>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>1.0 Colony_Forming_Units / milliliter</td>\n",
@@ -7074,11 +7065,11 @@
        "22478                 200                       #/100mL   \n",
        "22706             NO DATA                       #/100mL   \n",
        "...                   ...                           ...   \n",
-       "571178              440.0                     cfu/100ml   \n",
-       "571192              450.0                     cfu/100ml   \n",
-       "571213              140.0                     cfu/100ml   \n",
-       "571419              180.0                       #/100mL   \n",
-       "571476                1.0                     cfu/100ml   \n",
+       "571178                440                     cfu/100ml   \n",
+       "571192                450                     cfu/100ml   \n",
+       "571213                140                     cfu/100ml   \n",
+       "571419                180                       #/100mL   \n",
+       "571476                  1                     cfu/100ml   \n",
        "\n",
        "                                                  QA_flag  \\\n",
        "22182                                                 NaN   \n",
@@ -7131,10 +7122,10 @@
    "execution_count": 70,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:10.154256Z",
-     "iopub.status.busy": "2026-04-05T03:47:10.154070Z",
-     "iopub.status.idle": "2026-04-05T03:47:15.338141Z",
-     "shell.execute_reply": "2026-04-05T03:47:15.337478Z"
+     "iopub.execute_input": "2026-04-15T16:27:12.420180Z",
+     "iopub.status.busy": "2026-04-15T16:27:12.419954Z",
+     "iopub.status.idle": "2026-04-15T16:27:17.468342Z",
+     "shell.execute_reply": "2026-04-15T16:27:17.467731Z"
     }
    },
    "outputs": [
@@ -7159,20 +7150,12 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: '%' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: '%' converted to NaN\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
     },
@@ -7180,7 +7163,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(44.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(44.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(14.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(390.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -7226,10 +7211,10 @@
    "execution_count": 71,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:15.340152Z",
-     "iopub.status.busy": "2026-04-05T03:47:15.339963Z",
-     "iopub.status.idle": "2026-04-05T03:47:15.392335Z",
-     "shell.execute_reply": "2026-04-05T03:47:15.391708Z"
+     "iopub.execute_input": "2026-04-15T16:27:17.470282Z",
+     "iopub.status.busy": "2026-04-15T16:27:17.470052Z",
+     "iopub.status.idle": "2026-04-15T16:27:17.522764Z",
+     "shell.execute_reply": "2026-04-15T16:27:17.522139Z"
     }
    },
    "outputs": [
@@ -7305,35 +7290,35 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575693</th>\n",
-       "      <td>7.0</td>\n",
+       "      <td>7</td>\n",
        "      <td>MPN/100 ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>7.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575706</th>\n",
-       "      <td>870.0</td>\n",
+       "      <td>870</td>\n",
        "      <td>MPN/100 ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>870.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575710</th>\n",
-       "      <td>44.0</td>\n",
+       "      <td>44</td>\n",
        "      <td>MPN/100 ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>44.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575714</th>\n",
-       "      <td>14.0</td>\n",
+       "      <td>14</td>\n",
        "      <td>MPN/100 ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>14.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>575718</th>\n",
-       "      <td>390.0</td>\n",
+       "      <td>390</td>\n",
        "      <td>MPN/100 ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>390.0 Colony_Forming_Units / milliliter</td>\n",
@@ -7351,11 +7336,11 @@
        "37                  24200                     MPN/100mL   \n",
        "38                   7270                     MPN/100mL   \n",
        "...                   ...                           ...   \n",
-       "575693                7.0                    MPN/100 ml   \n",
-       "575706              870.0                    MPN/100 ml   \n",
-       "575710               44.0                    MPN/100 ml   \n",
-       "575714               14.0                    MPN/100 ml   \n",
-       "575718              390.0                    MPN/100 ml   \n",
+       "575693                  7                    MPN/100 ml   \n",
+       "575706                870                    MPN/100 ml   \n",
+       "575710                 44                    MPN/100 ml   \n",
+       "575714                 14                    MPN/100 ml   \n",
+       "575718                390                    MPN/100 ml   \n",
        "\n",
        "                                         QA_flag  \\\n",
        "15                                           NaN   \n",
@@ -7429,10 +7414,10 @@
    "execution_count": 72,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:15.394534Z",
-     "iopub.status.busy": "2026-04-05T03:47:15.394300Z",
-     "iopub.status.idle": "2026-04-05T03:47:15.397072Z",
-     "shell.execute_reply": "2026-04-05T03:47:15.396546Z"
+     "iopub.execute_input": "2026-04-15T16:27:17.524934Z",
+     "iopub.status.busy": "2026-04-15T16:27:17.524729Z",
+     "iopub.status.idle": "2026-04-15T16:27:17.527574Z",
+     "shell.execute_reply": "2026-04-15T16:27:17.527032Z"
     }
    },
    "outputs": [],
@@ -7445,10 +7430,10 @@
    "execution_count": 73,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:15.398910Z",
-     "iopub.status.busy": "2026-04-05T03:47:15.398730Z",
-     "iopub.status.idle": "2026-04-05T03:47:15.436935Z",
-     "shell.execute_reply": "2026-04-05T03:47:15.436269Z"
+     "iopub.execute_input": "2026-04-15T16:27:17.529374Z",
+     "iopub.status.busy": "2026-04-15T16:27:17.529178Z",
+     "iopub.status.idle": "2026-04-15T16:27:17.570615Z",
+     "shell.execute_reply": "2026-04-15T16:27:17.570011Z"
     }
    },
    "outputs": [
@@ -7475,10 +7460,10 @@
    "execution_count": 74,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:15.438839Z",
-     "iopub.status.busy": "2026-04-05T03:47:15.438652Z",
-     "iopub.status.idle": "2026-04-05T03:47:15.444922Z",
-     "shell.execute_reply": "2026-04-05T03:47:15.444398Z"
+     "iopub.execute_input": "2026-04-15T16:27:17.572562Z",
+     "iopub.status.busy": "2026-04-15T16:27:17.572371Z",
+     "iopub.status.idle": "2026-04-15T16:27:17.578530Z",
+     "shell.execute_reply": "2026-04-15T16:27:17.578022Z"
     }
    },
    "outputs": [
@@ -7510,10 +7495,10 @@
    "execution_count": 75,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:15.446874Z",
-     "iopub.status.busy": "2026-04-05T03:47:15.446688Z",
-     "iopub.status.idle": "2026-04-05T03:47:15.449756Z",
-     "shell.execute_reply": "2026-04-05T03:47:15.449146Z"
+     "iopub.execute_input": "2026-04-15T16:27:17.580304Z",
+     "iopub.status.busy": "2026-04-15T16:27:17.580132Z",
+     "iopub.status.idle": "2026-04-15T16:27:17.582465Z",
+     "shell.execute_reply": "2026-04-15T16:27:17.581992Z"
     }
    },
    "outputs": [],
@@ -7527,10 +7512,10 @@
    "execution_count": 76,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:15.451431Z",
-     "iopub.status.busy": "2026-04-05T03:47:15.451225Z",
-     "iopub.status.idle": "2026-04-05T03:47:35.288735Z",
-     "shell.execute_reply": "2026-04-05T03:47:35.288108Z"
+     "iopub.execute_input": "2026-04-15T16:27:17.584178Z",
+     "iopub.status.busy": "2026-04-15T16:27:17.583960Z",
+     "iopub.status.idle": "2026-04-15T16:27:36.958800Z",
+     "shell.execute_reply": "2026-04-15T16:27:36.958137Z"
     }
    },
    "outputs": [
@@ -7592,7 +7577,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>565358</th>\n",
-       "      <td>4980.0</td>\n",
+       "      <td>4980</td>\n",
        "      <td>mg/mL @25C</td>\n",
        "      <td>ResultTemperatureBasisText: updated from 25 de...</td>\n",
        "      <td>4003.4828342857154 Practical_Salinity_Units</td>\n",
@@ -7607,7 +7592,7 @@
        "263173              70.62                          ppth   \n",
        "263673              71.49                          ppth   \n",
        "270684   77.6666666666667                           ppt   \n",
-       "565358             4980.0                    mg/mL @25C   \n",
+       "565358               4980                    mg/mL @25C   \n",
        "\n",
        "                                                  QA_flag  \\\n",
        "30987                                                 NaN   \n",
@@ -7648,10 +7633,10 @@
    "execution_count": 77,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:47:35.290719Z",
-     "iopub.status.busy": "2026-04-05T03:47:35.290530Z",
-     "iopub.status.idle": "2026-04-05T03:48:05.192977Z",
-     "shell.execute_reply": "2026-04-05T03:48:05.192278Z"
+     "iopub.execute_input": "2026-04-15T16:27:36.960943Z",
+     "iopub.status.busy": "2026-04-15T16:27:36.960750Z",
+     "iopub.status.idle": "2026-04-15T16:28:11.450233Z",
+     "shell.execute_reply": "2026-04-15T16:28:11.449484Z"
     }
    },
    "outputs": [],
@@ -7668,10 +7653,10 @@
    "execution_count": 78,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:05.195205Z",
-     "iopub.status.busy": "2026-04-05T03:48:05.195016Z",
-     "iopub.status.idle": "2026-04-05T03:48:10.333753Z",
-     "shell.execute_reply": "2026-04-05T03:48:10.333014Z"
+     "iopub.execute_input": "2026-04-15T16:28:11.452676Z",
+     "iopub.status.busy": "2026-04-15T16:28:11.452461Z",
+     "iopub.status.idle": "2026-04-15T16:28:15.954500Z",
+     "shell.execute_reply": "2026-04-15T16:28:15.953852Z"
     }
    },
    "outputs": [
@@ -7924,10 +7909,10 @@
    "execution_count": 79,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:10.335828Z",
-     "iopub.status.busy": "2026-04-05T03:48:10.335638Z",
-     "iopub.status.idle": "2026-04-05T03:48:10.352468Z",
-     "shell.execute_reply": "2026-04-05T03:48:10.351697Z"
+     "iopub.execute_input": "2026-04-15T16:28:15.956561Z",
+     "iopub.status.busy": "2026-04-15T16:28:15.956370Z",
+     "iopub.status.idle": "2026-04-15T16:28:15.972950Z",
+     "shell.execute_reply": "2026-04-15T16:28:15.972438Z"
     }
    },
    "outputs": [
@@ -7971,10 +7956,10 @@
    "execution_count": 80,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:10.354479Z",
-     "iopub.status.busy": "2026-04-05T03:48:10.354253Z",
-     "iopub.status.idle": "2026-04-05T03:48:11.395220Z",
-     "shell.execute_reply": "2026-04-05T03:48:11.394556Z"
+     "iopub.execute_input": "2026-04-15T16:28:15.974718Z",
+     "iopub.status.busy": "2026-04-15T16:28:15.974524Z",
+     "iopub.status.idle": "2026-04-15T16:28:17.008822Z",
+     "shell.execute_reply": "2026-04-15T16:28:17.008142Z"
     }
    },
    "outputs": [
@@ -8147,10 +8132,10 @@
    "execution_count": 81,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:11.397180Z",
-     "iopub.status.busy": "2026-04-05T03:48:11.396965Z",
-     "iopub.status.idle": "2026-04-05T03:48:16.678462Z",
-     "shell.execute_reply": "2026-04-05T03:48:16.677704Z"
+     "iopub.execute_input": "2026-04-15T16:28:17.010698Z",
+     "iopub.status.busy": "2026-04-15T16:28:17.010507Z",
+     "iopub.status.idle": "2026-04-15T16:28:20.969051Z",
+     "shell.execute_reply": "2026-04-15T16:28:20.968436Z"
     }
    },
    "outputs": [
@@ -8202,10 +8187,10 @@
    "execution_count": 82,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:16.680548Z",
-     "iopub.status.busy": "2026-04-05T03:48:16.680354Z",
-     "iopub.status.idle": "2026-04-05T03:48:16.693874Z",
-     "shell.execute_reply": "2026-04-05T03:48:16.693182Z"
+     "iopub.execute_input": "2026-04-15T16:28:20.971195Z",
+     "iopub.status.busy": "2026-04-15T16:28:20.970984Z",
+     "iopub.status.idle": "2026-04-15T16:28:20.983857Z",
+     "shell.execute_reply": "2026-04-15T16:28:20.983327Z"
     }
    },
    "outputs": [
@@ -8340,10 +8325,10 @@
    "execution_count": 83,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:16.695894Z",
-     "iopub.status.busy": "2026-04-05T03:48:16.695702Z",
-     "iopub.status.idle": "2026-04-05T03:48:17.930567Z",
-     "shell.execute_reply": "2026-04-05T03:48:17.929952Z"
+     "iopub.execute_input": "2026-04-15T16:28:20.985617Z",
+     "iopub.status.busy": "2026-04-15T16:28:20.985436Z",
+     "iopub.status.idle": "2026-04-15T16:28:22.175193Z",
+     "shell.execute_reply": "2026-04-15T16:28:22.174557Z"
     }
    },
    "outputs": [
@@ -8487,10 +8472,10 @@
    "execution_count": 84,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:17.932677Z",
-     "iopub.status.busy": "2026-04-05T03:48:17.932491Z",
-     "iopub.status.idle": "2026-04-05T03:48:20.006983Z",
-     "shell.execute_reply": "2026-04-05T03:48:20.006391Z"
+     "iopub.execute_input": "2026-04-15T16:28:22.177278Z",
+     "iopub.status.busy": "2026-04-15T16:28:22.177065Z",
+     "iopub.status.idle": "2026-04-15T16:28:23.817460Z",
+     "shell.execute_reply": "2026-04-15T16:28:23.816823Z"
     }
    },
    "outputs": [
@@ -8535,10 +8520,10 @@
    "execution_count": 85,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:20.008947Z",
-     "iopub.status.busy": "2026-04-05T03:48:20.008765Z",
-     "iopub.status.idle": "2026-04-05T03:48:26.733110Z",
-     "shell.execute_reply": "2026-04-05T03:48:26.732357Z"
+     "iopub.execute_input": "2026-04-15T16:28:23.819478Z",
+     "iopub.status.busy": "2026-04-15T16:28:23.819275Z",
+     "iopub.status.idle": "2026-04-15T16:28:29.686366Z",
+     "shell.execute_reply": "2026-04-15T16:28:29.685719Z"
     }
    },
    "outputs": [
@@ -8574,15 +8559,15 @@
        "      <th>DataLoggerLine</th>\n",
        "      <th>ResultDetectionConditionText</th>\n",
        "      <th>...</th>\n",
-       "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Secchi</th>\n",
-       "      <th>QA_TP_Phosphorus</th>\n",
-       "      <th>QA_TDP_Phosphorus</th>\n",
        "      <th>QA_Other_Phosphorus</th>\n",
-       "      <th>QA_Fecal_Coliform</th>\n",
-       "      <th>QA_Temperature</th>\n",
        "      <th>QA_Sediment</th>\n",
+       "      <th>QA_Chlorophyll</th>\n",
        "      <th>QA_DO</th>\n",
+       "      <th>QA_Temperature</th>\n",
+       "      <th>QA_Conductivity</th>\n",
+       "      <th>QA_Secchi</th>\n",
+       "      <th>QA_Nitrogen</th>\n",
+       "      <th>QA_pH</th>\n",
        "      <th>QA_Salinity</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -8922,44 +8907,44 @@
        "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863            NaN   \n",
        "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462            NaN   \n",
        "\n",
-       "       ResultDetectionConditionText  ... QA_Turbidity QA_Secchi  \\\n",
-       "492014                          NaN  ...          NaN       NaN   \n",
-       "492535                          NaN  ...          NaN       NaN   \n",
-       "493640                          NaN  ...          NaN       NaN   \n",
-       "279987                          NaN  ...          NaN       NaN   \n",
-       "318613                          NaN  ...          NaN       NaN   \n",
-       "...                             ...  ...          ...       ...   \n",
-       "575729                          NaN  ...          NaN       NaN   \n",
-       "575730                          NaN  ...          NaN       NaN   \n",
-       "575731                          NaN  ...          NaN       NaN   \n",
-       "575732                          NaN  ...          NaN       NaN   \n",
-       "575733                          NaN  ...          NaN       NaN   \n",
+       "       ResultDetectionConditionText  ... QA_Other_Phosphorus QA_Sediment  \\\n",
+       "492014                          NaN  ...                 NaN         NaN   \n",
+       "492535                          NaN  ...                 NaN         NaN   \n",
+       "493640                          NaN  ...                 NaN         NaN   \n",
+       "279987                          NaN  ...                 NaN         NaN   \n",
+       "318613                          NaN  ...                 NaN         NaN   \n",
+       "...                             ...  ...                 ...         ...   \n",
+       "575729                          NaN  ...                 NaN         NaN   \n",
+       "575730                          NaN  ...                 NaN         NaN   \n",
+       "575731                          NaN  ...                 NaN         NaN   \n",
+       "575732                          NaN  ...                 NaN         NaN   \n",
+       "575733                          NaN  ...                 NaN         NaN   \n",
        "\n",
-       "       QA_TP_Phosphorus QA_TDP_Phosphorus QA_Other_Phosphorus  \\\n",
-       "492014              NaN               NaN                 NaN   \n",
-       "492535              NaN               NaN                 NaN   \n",
-       "493640              NaN               NaN                 NaN   \n",
-       "279987              NaN               NaN                 NaN   \n",
-       "318613              NaN               NaN                 NaN   \n",
-       "...                 ...               ...                 ...   \n",
-       "575729              NaN               NaN                 NaN   \n",
-       "575730              NaN               NaN                 NaN   \n",
-       "575731              NaN               NaN                 NaN   \n",
-       "575732              NaN               NaN                 NaN   \n",
-       "575733              NaN               NaN                 NaN   \n",
+       "       QA_Chlorophyll QA_DO QA_Temperature QA_Conductivity QA_Secchi  \\\n",
+       "492014            NaN   NaN            NaN             NaN       NaN   \n",
+       "492535            NaN   NaN            NaN             NaN       NaN   \n",
+       "493640            NaN   NaN            NaN             NaN       NaN   \n",
+       "279987            NaN   NaN            NaN             NaN       NaN   \n",
+       "318613            NaN   NaN            NaN             NaN       NaN   \n",
+       "...               ...   ...            ...             ...       ...   \n",
+       "575729            NaN   NaN            NaN             NaN       NaN   \n",
+       "575730            NaN   NaN            NaN             NaN       NaN   \n",
+       "575731            NaN   NaN            NaN             NaN       NaN   \n",
+       "575732            NaN   NaN            NaN             NaN       NaN   \n",
+       "575733            NaN   NaN            NaN             NaN       NaN   \n",
        "\n",
-       "       QA_Fecal_Coliform QA_Temperature QA_Sediment QA_DO QA_Salinity  \n",
-       "492014               NaN            NaN         NaN   NaN         NaN  \n",
-       "492535               NaN            NaN         NaN   NaN         NaN  \n",
-       "493640               NaN            NaN         NaN   NaN         NaN  \n",
-       "279987               NaN            NaN         NaN   NaN         NaN  \n",
-       "318613               NaN            NaN         NaN   NaN         NaN  \n",
-       "...                  ...            ...         ...   ...         ...  \n",
-       "575729               NaN            NaN         NaN   NaN         NaN  \n",
-       "575730               NaN            NaN         NaN   NaN         NaN  \n",
-       "575731               NaN            NaN         NaN   NaN         NaN  \n",
-       "575732               NaN            NaN         NaN   NaN         NaN  \n",
-       "575733               NaN            NaN         NaN   NaN         NaN  \n",
+       "       QA_Nitrogen QA_pH QA_Salinity  \n",
+       "492014         NaN   NaN         NaN  \n",
+       "492535         NaN   NaN         NaN  \n",
+       "493640         NaN   NaN         NaN  \n",
+       "279987         NaN   NaN         NaN  \n",
+       "318613         NaN   NaN         NaN  \n",
+       "...            ...   ...         ...  \n",
+       "575729         NaN   NaN         NaN  \n",
+       "575730         NaN   NaN         NaN  \n",
+       "575731         NaN   NaN         NaN  \n",
+       "575732         NaN   NaN         NaN  \n",
+       "575733         NaN   NaN         NaN  \n",
        "\n",
        "[520571 rows x 118 columns]"
       ]
@@ -8980,10 +8965,10 @@
    "execution_count": 86,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:26.735297Z",
-     "iopub.status.busy": "2026-04-05T03:48:26.735108Z",
-     "iopub.status.idle": "2026-04-05T03:48:26.738666Z",
-     "shell.execute_reply": "2026-04-05T03:48:26.737932Z"
+     "iopub.execute_input": "2026-04-15T16:28:29.688283Z",
+     "iopub.status.busy": "2026-04-15T16:28:29.688053Z",
+     "iopub.status.idle": "2026-04-15T16:28:29.691332Z",
+     "shell.execute_reply": "2026-04-15T16:28:29.690770Z"
     }
    },
    "outputs": [
@@ -9005,10 +8990,10 @@
    "execution_count": 87,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:26.740516Z",
-     "iopub.status.busy": "2026-04-05T03:48:26.740311Z",
-     "iopub.status.idle": "2026-04-05T03:48:26.743764Z",
-     "shell.execute_reply": "2026-04-05T03:48:26.743038Z"
+     "iopub.execute_input": "2026-04-15T16:28:29.693024Z",
+     "iopub.status.busy": "2026-04-15T16:28:29.692844Z",
+     "iopub.status.idle": "2026-04-15T16:28:29.695814Z",
+     "shell.execute_reply": "2026-04-15T16:28:29.695292Z"
     }
    },
    "outputs": [
@@ -9030,10 +9015,10 @@
    "execution_count": 88,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:26.745616Z",
-     "iopub.status.busy": "2026-04-05T03:48:26.745437Z",
-     "iopub.status.idle": "2026-04-05T03:48:26.773930Z",
-     "shell.execute_reply": "2026-04-05T03:48:26.773300Z"
+     "iopub.execute_input": "2026-04-15T16:28:29.697485Z",
+     "iopub.status.busy": "2026-04-15T16:28:29.697299Z",
+     "iopub.status.idle": "2026-04-15T16:28:29.724856Z",
+     "shell.execute_reply": "2026-04-15T16:28:29.724238Z"
     }
    },
    "outputs": [
@@ -9098,10 +9083,10 @@
    "execution_count": 89,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:26.775886Z",
-     "iopub.status.busy": "2026-04-05T03:48:26.775704Z",
-     "iopub.status.idle": "2026-04-05T03:48:27.547033Z",
-     "shell.execute_reply": "2026-04-05T03:48:27.546340Z"
+     "iopub.execute_input": "2026-04-15T16:28:29.726897Z",
+     "iopub.status.busy": "2026-04-15T16:28:29.726715Z",
+     "iopub.status.idle": "2026-04-15T16:28:30.446091Z",
+     "shell.execute_reply": "2026-04-15T16:28:30.445394Z"
     }
    },
    "outputs": [],
@@ -9115,10 +9100,10 @@
    "execution_count": 90,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:27.549168Z",
-     "iopub.status.busy": "2026-04-05T03:48:27.548980Z",
-     "iopub.status.idle": "2026-04-05T03:48:27.553627Z",
-     "shell.execute_reply": "2026-04-05T03:48:27.552902Z"
+     "iopub.execute_input": "2026-04-15T16:28:30.448560Z",
+     "iopub.status.busy": "2026-04-15T16:28:30.448369Z",
+     "iopub.status.idle": "2026-04-15T16:28:30.452612Z",
+     "shell.execute_reply": "2026-04-15T16:28:30.452002Z"
     }
    },
    "outputs": [
@@ -9134,11 +9119,11 @@
        "       'E_coli', 'DetectionQuantitationLimitTypeName',\n",
        "       'DetectionQuantitationLimitMeasure/MeasureValue',\n",
        "       'DetectionQuantitationLimitMeasure/MeasureUnitCode',\n",
-       "       'Activity_datetime', 'Depth', 'QA_Chlorophyll', 'QA_pH', 'QA_E_coli',\n",
-       "       'QA_Carbon', 'QA_Conductivity', 'QA_Nitrogen', 'QA_Turbidity',\n",
-       "       'QA_Secchi', 'QA_TP_Phosphorus', 'QA_TDP_Phosphorus',\n",
-       "       'QA_Other_Phosphorus', 'QA_Fecal_Coliform', 'QA_Temperature',\n",
-       "       'QA_Sediment', 'QA_DO', 'QA_Salinity'],\n",
+       "       'Activity_datetime', 'Depth', 'QA_Carbon', 'QA_E_coli', 'QA_Turbidity',\n",
+       "       'QA_Fecal_Coliform', 'QA_TP_Phosphorus', 'QA_TDP_Phosphorus',\n",
+       "       'QA_Other_Phosphorus', 'QA_Sediment', 'QA_Chlorophyll', 'QA_DO',\n",
+       "       'QA_Temperature', 'QA_Conductivity', 'QA_Secchi', 'QA_Nitrogen',\n",
+       "       'QA_pH', 'QA_Salinity'],\n",
        "      dtype='object')"
       ]
      },
@@ -9157,10 +9142,10 @@
    "execution_count": 91,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:27.555443Z",
-     "iopub.status.busy": "2026-04-05T03:48:27.555219Z",
-     "iopub.status.idle": "2026-04-05T03:48:27.569419Z",
-     "shell.execute_reply": "2026-04-05T03:48:27.568850Z"
+     "iopub.execute_input": "2026-04-15T16:28:30.454381Z",
+     "iopub.status.busy": "2026-04-15T16:28:30.454206Z",
+     "iopub.status.idle": "2026-04-15T16:28:30.466251Z",
+     "shell.execute_reply": "2026-04-15T16:28:30.465771Z"
     }
    },
    "outputs": [
@@ -9196,15 +9181,15 @@
        "      <th>pH</th>\n",
        "      <th>Salinity</th>\n",
        "      <th>...</th>\n",
-       "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Secchi</th>\n",
-       "      <th>QA_TP_Phosphorus</th>\n",
-       "      <th>QA_TDP_Phosphorus</th>\n",
        "      <th>QA_Other_Phosphorus</th>\n",
-       "      <th>QA_Fecal_Coliform</th>\n",
-       "      <th>QA_Temperature</th>\n",
        "      <th>QA_Sediment</th>\n",
+       "      <th>QA_Chlorophyll</th>\n",
        "      <th>QA_DO</th>\n",
+       "      <th>QA_Temperature</th>\n",
+       "      <th>QA_Conductivity</th>\n",
+       "      <th>QA_Secchi</th>\n",
+       "      <th>QA_Nitrogen</th>\n",
+       "      <th>QA_pH</th>\n",
        "      <th>QA_Salinity</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -9363,26 +9348,19 @@
        "279987       STORET    NaN         NaN  NaN  NaN    38.468 dimensionless  ...   \n",
        "318613       STORET    NaN         NaN  NaN  NaN    34.521 dimensionless  ...   \n",
        "\n",
-       "       QA_Turbidity QA_Secchi QA_TP_Phosphorus QA_TDP_Phosphorus  \\\n",
-       "492014          NaN       NaN              NaN               NaN   \n",
-       "492535          NaN       NaN              NaN               NaN   \n",
-       "493640          NaN       NaN              NaN               NaN   \n",
-       "279987          NaN       NaN              NaN               NaN   \n",
-       "318613          NaN       NaN              NaN               NaN   \n",
+       "       QA_Other_Phosphorus QA_Sediment QA_Chlorophyll QA_DO QA_Temperature  \\\n",
+       "492014                 NaN         NaN            NaN   NaN            NaN   \n",
+       "492535                 NaN         NaN            NaN   NaN            NaN   \n",
+       "493640                 NaN         NaN            NaN   NaN            NaN   \n",
+       "279987                 NaN         NaN            NaN   NaN            NaN   \n",
+       "318613                 NaN         NaN            NaN   NaN            NaN   \n",
        "\n",
-       "       QA_Other_Phosphorus QA_Fecal_Coliform QA_Temperature  QA_Sediment  \\\n",
-       "492014                 NaN               NaN            NaN          NaN   \n",
-       "492535                 NaN               NaN            NaN          NaN   \n",
-       "493640                 NaN               NaN            NaN          NaN   \n",
-       "279987                 NaN               NaN            NaN          NaN   \n",
-       "318613                 NaN               NaN            NaN          NaN   \n",
-       "\n",
-       "       QA_DO QA_Salinity  \n",
-       "492014   NaN         NaN  \n",
-       "492535   NaN         NaN  \n",
-       "493640   NaN         NaN  \n",
-       "279987   NaN         NaN  \n",
-       "318613   NaN         NaN  \n",
+       "       QA_Conductivity QA_Secchi  QA_Nitrogen QA_pH QA_Salinity  \n",
+       "492014             NaN       NaN          NaN   NaN         NaN  \n",
+       "492535             NaN       NaN          NaN   NaN         NaN  \n",
+       "493640             NaN       NaN          NaN   NaN         NaN  \n",
+       "279987             NaN       NaN          NaN   NaN         NaN  \n",
+       "318613             NaN       NaN          NaN   NaN         NaN  \n",
        "\n",
        "[5 rows x 45 columns]"
       ]
@@ -9402,10 +9380,10 @@
    "execution_count": 92,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:27.571155Z",
-     "iopub.status.busy": "2026-04-05T03:48:27.570981Z",
-     "iopub.status.idle": "2026-04-05T03:48:28.108152Z",
-     "shell.execute_reply": "2026-04-05T03:48:28.107473Z"
+     "iopub.execute_input": "2026-04-15T16:28:30.467955Z",
+     "iopub.status.busy": "2026-04-15T16:28:30.467768Z",
+     "iopub.status.idle": "2026-04-15T16:28:31.009306Z",
+     "shell.execute_reply": "2026-04-15T16:28:31.008650Z"
     }
    },
    "outputs": [
@@ -9414,10 +9392,10 @@
       "text/plain": [
        "['Sediment',\n",
        " 'QA_Carbon',\n",
-       " 'QA_Conductivity',\n",
        " 'QA_TDP_Phosphorus',\n",
        " 'QA_Sediment',\n",
-       " 'QA_DO']"
+       " 'QA_DO',\n",
+       " 'QA_Conductivity']"
       ]
      },
      "execution_count": 92,
@@ -9437,10 +9415,10 @@
    "execution_count": 93,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:28.110061Z",
-     "iopub.status.busy": "2026-04-05T03:48:28.109876Z",
-     "iopub.status.idle": "2026-04-05T03:48:28.573019Z",
-     "shell.execute_reply": "2026-04-05T03:48:28.572265Z"
+     "iopub.execute_input": "2026-04-15T16:28:31.011260Z",
+     "iopub.status.busy": "2026-04-15T16:28:31.011036Z",
+     "iopub.status.idle": "2026-04-15T16:28:31.464404Z",
+     "shell.execute_reply": "2026-04-15T16:28:31.463746Z"
     }
    },
    "outputs": [

--- a/demos/Harmonize_CapeCod_Simple.ipynb
+++ b/demos/Harmonize_CapeCod_Simple.ipynb
@@ -54,10 +54,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:33.602163Z",
-     "iopub.status.busy": "2026-04-05T03:48:33.601925Z",
-     "iopub.status.idle": "2026-04-05T03:48:33.608440Z",
-     "shell.execute_reply": "2026-04-05T03:48:33.607767Z"
+     "iopub.execute_input": "2026-04-15T16:28:36.390552Z",
+     "iopub.status.busy": "2026-04-15T16:28:36.390364Z",
+     "iopub.status.idle": "2026-04-15T16:28:36.396296Z",
+     "shell.execute_reply": "2026-04-15T16:28:36.395830Z"
     }
    },
    "outputs": [],
@@ -82,10 +82,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:33.610387Z",
-     "iopub.status.busy": "2026-04-05T03:48:33.610173Z",
-     "iopub.status.idle": "2026-04-05T03:48:34.229008Z",
-     "shell.execute_reply": "2026-04-05T03:48:34.228308Z"
+     "iopub.execute_input": "2026-04-15T16:28:36.398054Z",
+     "iopub.status.busy": "2026-04-15T16:28:36.397877Z",
+     "iopub.status.idle": "2026-04-15T16:28:36.976213Z",
+     "shell.execute_reply": "2026-04-15T16:28:36.975657Z"
     }
    },
    "outputs": [],
@@ -98,10 +98,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:34.231263Z",
-     "iopub.status.busy": "2026-04-05T03:48:34.230995Z",
-     "iopub.status.idle": "2026-04-05T03:48:34.233906Z",
-     "shell.execute_reply": "2026-04-05T03:48:34.233304Z"
+     "iopub.execute_input": "2026-04-15T16:28:36.978595Z",
+     "iopub.status.busy": "2026-04-15T16:28:36.978328Z",
+     "iopub.status.idle": "2026-04-15T16:28:36.980898Z",
+     "shell.execute_reply": "2026-04-15T16:28:36.980433Z"
     }
    },
    "outputs": [],
@@ -116,10 +116,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:34.235867Z",
-     "iopub.status.busy": "2026-04-05T03:48:34.235679Z",
-     "iopub.status.idle": "2026-04-05T03:48:37.862636Z",
-     "shell.execute_reply": "2026-04-05T03:48:37.861989Z"
+     "iopub.execute_input": "2026-04-15T16:28:36.982614Z",
+     "iopub.status.busy": "2026-04-15T16:28:36.982443Z",
+     "iopub.status.idle": "2026-04-15T16:28:39.250913Z",
+     "shell.execute_reply": "2026-04-15T16:28:39.250296Z"
     }
    },
    "outputs": [
@@ -161,10 +161,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:37.864724Z",
-     "iopub.status.busy": "2026-04-05T03:48:37.864452Z",
-     "iopub.status.idle": "2026-04-05T03:48:39.117588Z",
-     "shell.execute_reply": "2026-04-05T03:48:39.116903Z"
+     "iopub.execute_input": "2026-04-15T16:28:39.264796Z",
+     "iopub.status.busy": "2026-04-15T16:28:39.264503Z",
+     "iopub.status.idle": "2026-04-15T16:28:39.538701Z",
+     "shell.execute_reply": "2026-04-15T16:28:39.537976Z"
     }
    },
    "outputs": [],
@@ -180,10 +180,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:39.119934Z",
-     "iopub.status.busy": "2026-04-05T03:48:39.119722Z",
-     "iopub.status.idle": "2026-04-05T03:48:39.123572Z",
-     "shell.execute_reply": "2026-04-05T03:48:39.122994Z"
+     "iopub.execute_input": "2026-04-15T16:28:39.541158Z",
+     "iopub.status.busy": "2026-04-15T16:28:39.540934Z",
+     "iopub.status.idle": "2026-04-15T16:28:39.544485Z",
+     "shell.execute_reply": "2026-04-15T16:28:39.543958Z"
     }
    },
    "outputs": [],
@@ -226,10 +226,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:39.125621Z",
-     "iopub.status.busy": "2026-04-05T03:48:39.125417Z",
-     "iopub.status.idle": "2026-04-05T03:48:39.128445Z",
-     "shell.execute_reply": "2026-04-05T03:48:39.127703Z"
+     "iopub.execute_input": "2026-04-15T16:28:39.546273Z",
+     "iopub.status.busy": "2026-04-15T16:28:39.546070Z",
+     "iopub.status.idle": "2026-04-15T16:28:39.548737Z",
+     "shell.execute_reply": "2026-04-15T16:28:39.548142Z"
     }
    },
    "outputs": [],
@@ -242,22 +242,13 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:39.130250Z",
-     "iopub.status.busy": "2026-04-05T03:48:39.130051Z",
-     "iopub.status.idle": "2026-04-05T03:48:43.367975Z",
-     "shell.execute_reply": "2026-04-05T03:48:43.367198Z"
+     "iopub.execute_input": "2026-04-15T16:28:39.550464Z",
+     "iopub.status.busy": "2026-04-15T16:28:39.550276Z",
+     "iopub.status.idle": "2026-04-15T16:28:44.480418Z",
+     "shell.execute_reply": "2026-04-15T16:28:44.479817Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:153: DtypeWarning: Columns (8,10,13,15,17,19,20,21,22,23,28,31,33,34,36,38,60,64,65,66,67,68,69,70,71,72) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Query for results\n",
     "# Note: large quieries like this can take up a lot of RAM and may give a DtypeWarning,\n",
@@ -270,10 +261,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:43.370610Z",
-     "iopub.status.busy": "2026-04-05T03:48:43.370379Z",
-     "iopub.status.idle": "2026-04-05T03:48:43.594545Z",
-     "shell.execute_reply": "2026-04-05T03:48:43.593827Z"
+     "iopub.execute_input": "2026-04-15T16:28:44.482883Z",
+     "iopub.status.busy": "2026-04-15T16:28:44.482656Z",
+     "iopub.status.idle": "2026-04-15T16:28:44.690272Z",
+     "shell.execute_reply": "2026-04-15T16:28:44.689615Z"
     }
    },
    "outputs": [
@@ -404,7 +395,7 @@
        "      <td>EST</td>\n",
        "      <td>CRWA-ROB</td>\n",
        "      <td>STORET-591631481</td>\n",
-       "      <td>130809111433.0</td>\n",
+       "      <td>130809111433</td>\n",
        "      <td>NaN</td>\n",
        "      <td>...</td>\n",
        "      <td>NaN</td>\n",
@@ -644,18 +635,18 @@
        "575733                    NaN                            NaN   \n",
        "575734                    NaN                            NaN   \n",
        "\n",
-       "       MonitoringLocationIdentifier   ResultIdentifier  DataLoggerLine  \\\n",
-       "0                   BRC-C-02-02-020  STORET-1039097035             NaN   \n",
-       "1                      OARS-CND-161   STORET-838568413             NaN   \n",
-       "2                      OARS-SUD-064   STORET-838568309             NaN   \n",
-       "3                          CRWA-ROB   STORET-591631481  130809111433.0   \n",
-       "4                         WTGHA-M41  STORET-1041401688             NaN   \n",
-       "...                             ...                ...             ...   \n",
-       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866             NaN   \n",
-       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862             NaN   \n",
-       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863             NaN   \n",
-       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462             NaN   \n",
-       "575734     11NPSWRD_WQX-CACO_SLOUGH   STORET-740745800             NaN   \n",
+       "       MonitoringLocationIdentifier   ResultIdentifier DataLoggerLine  \\\n",
+       "0                   BRC-C-02-02-020  STORET-1039097035            NaN   \n",
+       "1                      OARS-CND-161   STORET-838568413            NaN   \n",
+       "2                      OARS-SUD-064   STORET-838568309            NaN   \n",
+       "3                          CRWA-ROB   STORET-591631481   130809111433   \n",
+       "4                         WTGHA-M41  STORET-1041401688            NaN   \n",
+       "...                             ...                ...            ...   \n",
+       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866            NaN   \n",
+       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862            NaN   \n",
+       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863            NaN   \n",
+       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462            NaN   \n",
+       "575734     11NPSWRD_WQX-CACO_SLOUGH   STORET-740745800            NaN   \n",
        "\n",
        "       ResultDetectionConditionText  ... AnalysisEndTime/TimeZoneCode  \\\n",
        "0                               NaN  ...                          NaN   \n",
@@ -761,10 +752,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:43.596603Z",
-     "iopub.status.busy": "2026-04-05T03:48:43.596397Z",
-     "iopub.status.idle": "2026-04-05T03:48:43.599855Z",
-     "shell.execute_reply": "2026-04-05T03:48:43.599285Z"
+     "iopub.execute_input": "2026-04-15T16:28:44.692394Z",
+     "iopub.status.busy": "2026-04-15T16:28:44.692183Z",
+     "iopub.status.idle": "2026-04-15T16:28:44.695494Z",
+     "shell.execute_reply": "2026-04-15T16:28:44.695024Z"
     }
    },
    "outputs": [],
@@ -779,10 +770,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:48:43.601625Z",
-     "iopub.status.busy": "2026-04-05T03:48:43.601443Z",
-     "iopub.status.idle": "2026-04-05T03:54:43.623511Z",
-     "shell.execute_reply": "2026-04-05T03:54:43.622734Z"
+     "iopub.execute_input": "2026-04-15T16:28:44.697277Z",
+     "iopub.status.busy": "2026-04-15T16:28:44.697062Z",
+     "iopub.status.idle": "2026-04-15T16:34:14.953845Z",
+     "shell.execute_reply": "2026-04-15T16:34:14.953146Z"
     }
    },
    "outputs": [
@@ -806,9 +797,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/cm2' UNDEFINED UNIT for Chlorophyll\n",
-      "  warn(\"WARNING: \" + problem)\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/m3' UNDEFINED UNIT for Chlorophyll\n",
+      "  warn(\"WARNING: \" + problem)\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'ug/cm2' UNDEFINED UNIT for Chlorophyll\n",
       "  warn(\"WARNING: \" + problem)\n"
      ]
     },
@@ -824,7 +815,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.004, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.004, 'milligram / liter')>\n",
       " <Quantity(0.0055, 'milligram / liter')>\n",
       " <Quantity(0.00948, 'milligram / liter')> ...\n",
       " <Quantity(0.0007, 'milligram / liter')>\n",
@@ -853,7 +844,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(590.0, 'microsiemens / centimeter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(590.0, 'microsiemens / centimeter')>\n",
       " <Quantity(43500.0, 'microsiemens / centimeter')>\n",
       " <Quantity(349.0, 'microsiemens / centimeter')> ...\n",
       " <Quantity(465.6, 'microsiemens / centimeter')>\n",
@@ -876,7 +867,7 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: '%' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.25, 'meter')> <Quantity(4.25, 'meter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.25, 'meter')> <Quantity(4.25, 'meter')>\n",
       " <Quantity(3.5, 'meter')> ... <Quantity(17.0, 'meter')>\n",
       " <Quantity(16.0, 'meter')> <Quantity(7.8, 'meter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -894,7 +885,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.6, 'milligram / liter')> <Quantity(9.4, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.6, 'milligram / liter')> <Quantity(9.4, 'milligram / liter')>\n",
       " <Quantity(10.3, 'milligram / liter')> ...\n",
       " <Quantity(4.14, 'milligram / liter')>\n",
       " <Quantity(10.65, 'milligram / liter')>\n",
@@ -923,8 +914,6 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
     },
@@ -933,6 +922,10 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: '%' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
     },
@@ -940,11 +933,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: '%' converted to NaN\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(44.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(44.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(14.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(390.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -964,8 +955,6 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
@@ -974,7 +963,9 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(140.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(140.0, 'Colony_Forming_Units / milliliter')>\n",
       " nan <Quantity(1.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
      ]
@@ -1025,7 +1016,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.926976, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.926976, 'milligram / liter')>\n",
       " <Quantity(1.571196, 'milligram / liter')>\n",
       " <Quantity(0.816144, 'milligram / liter')> ...\n",
       " <Quantity(0.238, 'milligram / liter')>\n",
@@ -1062,7 +1053,7 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'umol/L * H2O' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.05, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.05, 'milligram / liter')>\n",
       " <Quantity(7.57, 'milligram / liter')>\n",
       " <Quantity(3.5, 'milligram / liter')> ...\n",
       " <Quantity(4.1, 'milligram / liter')>\n",
@@ -1097,7 +1088,7 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'umol/L * H2O' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
       " <Quantity(0.024, 'milligram / liter')>\n",
       " <Quantity(0.05, 'milligram / liter')> ...\n",
       " <Quantity(0.008, 'milligram / liter')>\n",
@@ -1141,8 +1132,14 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'deg C' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(30.33, 'Practical_Salinity_Units')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(30.33, 'Practical_Salinity_Units')>\n",
       " <Quantity(30.48, 'Practical_Salinity_Units')>\n",
       " <Quantity(33.3, 'Practical_Salinity_Units')> ...\n",
       " <Quantity(0.11, 'Practical_Salinity_Units')>\n",
@@ -1182,8 +1179,14 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(22.18, 'degree_Celsius')> <Quantity(23.01, 'degree_Celsius')>\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(22.18, 'degree_Celsius')> <Quantity(23.01, 'degree_Celsius')>\n",
       " <Quantity(17.39, 'degree_Celsius')> ... <Quantity(2.9, 'degree_Celsius')>\n",
       " <Quantity(1.5, 'degree_Celsius')> <Quantity(3.9, 'degree_Celsius')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1202,16 +1205,16 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/harmonize.py:149: UserWarning: Bad Turbidity unit: count\n",
-      "  warn(f\"Bad Turbidity unit: {unit}\")\n"
+      "  warn(f\"Bad Turbidity unit: {unit}\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'count' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.6, 'Nephelometric_Turbidity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.6, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(1.0, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(4.2, 'Nephelometric_Turbidity_Units')> ...\n",
       " <Quantity(2.1, 'Nephelometric_Turbidity_Units')>\n",
@@ -1240,7 +1243,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.3, 'dimensionless')> <Quantity(8.16, 'dimensionless')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.3, 'dimensionless')> <Quantity(8.16, 'dimensionless')>\n",
       " <Quantity(7.99, 'dimensionless')> ... <Quantity(7.4, 'dimensionless')>\n",
       " <Quantity(7.5, 'dimensionless')> <Quantity(7.4, 'dimensionless')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1373,7 +1376,7 @@
        "      <td>EST</td>\n",
        "      <td>CRWA-ROB</td>\n",
        "      <td>STORET-591631481</td>\n",
-       "      <td>130809111433.0</td>\n",
+       "      <td>130809111433</td>\n",
        "      <td>NaN</td>\n",
        "      <td>...</td>\n",
        "      <td>NaN</td>\n",
@@ -1613,18 +1616,18 @@
        "575733                    NaN                            NaN   \n",
        "575734                    NaN                            NaN   \n",
        "\n",
-       "       MonitoringLocationIdentifier   ResultIdentifier  DataLoggerLine  \\\n",
-       "0                   BRC-C-02-02-020  STORET-1039097035             NaN   \n",
-       "1                      OARS-CND-161   STORET-838568413             NaN   \n",
-       "2                      OARS-SUD-064   STORET-838568309             NaN   \n",
-       "3                          CRWA-ROB   STORET-591631481  130809111433.0   \n",
-       "4                         WTGHA-M41  STORET-1041401688             NaN   \n",
-       "...                             ...                ...             ...   \n",
-       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866             NaN   \n",
-       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862             NaN   \n",
-       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863             NaN   \n",
-       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462             NaN   \n",
-       "575734     11NPSWRD_WQX-CACO_SLOUGH   STORET-740745800             NaN   \n",
+       "       MonitoringLocationIdentifier   ResultIdentifier DataLoggerLine  \\\n",
+       "0                   BRC-C-02-02-020  STORET-1039097035            NaN   \n",
+       "1                      OARS-CND-161   STORET-838568413            NaN   \n",
+       "2                      OARS-SUD-064   STORET-838568309            NaN   \n",
+       "3                          CRWA-ROB   STORET-591631481   130809111433   \n",
+       "4                         WTGHA-M41  STORET-1041401688            NaN   \n",
+       "...                             ...                ...            ...   \n",
+       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866            NaN   \n",
+       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862            NaN   \n",
+       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863            NaN   \n",
+       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462            NaN   \n",
+       "575734     11NPSWRD_WQX-CACO_SLOUGH   STORET-740745800            NaN   \n",
        "\n",
        "       ResultDetectionConditionText  ... Carbon Phosphorus TP_Phosphorus  \\\n",
        "0                               NaN  ...    NaN        NaN           NaN   \n",
@@ -1686,10 +1689,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:43.625646Z",
-     "iopub.status.busy": "2026-04-05T03:54:43.625438Z",
-     "iopub.status.idle": "2026-04-05T03:54:47.792070Z",
-     "shell.execute_reply": "2026-04-05T03:54:47.791406Z"
+     "iopub.execute_input": "2026-04-15T16:34:14.955766Z",
+     "iopub.status.busy": "2026-04-15T16:34:14.955572Z",
+     "iopub.status.idle": "2026-04-15T16:34:17.833457Z",
+     "shell.execute_reply": "2026-04-15T16:34:17.832893Z"
     }
    },
    "outputs": [
@@ -1720,10 +1723,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:47.794530Z",
-     "iopub.status.busy": "2026-04-05T03:54:47.794230Z",
-     "iopub.status.idle": "2026-04-05T03:54:48.577006Z",
-     "shell.execute_reply": "2026-04-05T03:54:48.576162Z"
+     "iopub.execute_input": "2026-04-15T16:34:17.835711Z",
+     "iopub.status.busy": "2026-04-15T16:34:17.835529Z",
+     "iopub.status.idle": "2026-04-15T16:34:18.566539Z",
+     "shell.execute_reply": "2026-04-15T16:34:18.565852Z"
     }
    },
    "outputs": [
@@ -1760,10 +1763,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:48.579271Z",
-     "iopub.status.busy": "2026-04-05T03:54:48.578960Z",
-     "iopub.status.idle": "2026-04-05T03:54:49.593868Z",
-     "shell.execute_reply": "2026-04-05T03:54:49.593159Z"
+     "iopub.execute_input": "2026-04-15T16:34:18.568707Z",
+     "iopub.status.busy": "2026-04-15T16:34:18.568408Z",
+     "iopub.status.idle": "2026-04-15T16:34:19.461648Z",
+     "shell.execute_reply": "2026-04-15T16:34:19.460993Z"
     }
    },
    "outputs": [
@@ -1806,10 +1809,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:49.595834Z",
-     "iopub.status.busy": "2026-04-05T03:54:49.595622Z",
-     "iopub.status.idle": "2026-04-05T03:54:49.598854Z",
-     "shell.execute_reply": "2026-04-05T03:54:49.598117Z"
+     "iopub.execute_input": "2026-04-15T16:34:19.463653Z",
+     "iopub.status.busy": "2026-04-15T16:34:19.463455Z",
+     "iopub.status.idle": "2026-04-15T16:34:19.466387Z",
+     "shell.execute_reply": "2026-04-15T16:34:19.465853Z"
     }
    },
    "outputs": [],
@@ -1822,10 +1825,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:49.600689Z",
-     "iopub.status.busy": "2026-04-05T03:54:49.600488Z",
-     "iopub.status.idle": "2026-04-05T03:54:53.180762Z",
-     "shell.execute_reply": "2026-04-05T03:54:53.180085Z"
+     "iopub.execute_input": "2026-04-15T16:34:19.468062Z",
+     "iopub.status.busy": "2026-04-15T16:34:19.467888Z",
+     "iopub.status.idle": "2026-04-15T16:34:22.503131Z",
+     "shell.execute_reply": "2026-04-15T16:34:22.502406Z"
     }
    },
    "outputs": [],
@@ -1853,10 +1856,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:53.183216Z",
-     "iopub.status.busy": "2026-04-05T03:54:53.183023Z",
-     "iopub.status.idle": "2026-04-05T03:54:59.818510Z",
-     "shell.execute_reply": "2026-04-05T03:54:59.817800Z"
+     "iopub.execute_input": "2026-04-15T16:34:22.505547Z",
+     "iopub.status.busy": "2026-04-15T16:34:22.505343Z",
+     "iopub.status.idle": "2026-04-15T16:34:28.207067Z",
+     "shell.execute_reply": "2026-04-15T16:34:28.206393Z"
     }
    },
    "outputs": [
@@ -1892,15 +1895,15 @@
        "      <th>DataLoggerLine</th>\n",
        "      <th>ResultDetectionConditionText</th>\n",
        "      <th>...</th>\n",
-       "      <th>QA_TP_Phosphorus</th>\n",
-       "      <th>QA_TDP_Phosphorus</th>\n",
        "      <th>QA_Other_Phosphorus</th>\n",
-       "      <th>QA_Conductivity</th>\n",
-       "      <th>QA_Secchi</th>\n",
-       "      <th>QA_Fecal_Coliform</th>\n",
-       "      <th>QA_Sediment</th>\n",
-       "      <th>QA_Nitrogen</th>\n",
+       "      <th>QA_Chlorophyll</th>\n",
        "      <th>QA_E_coli</th>\n",
+       "      <th>QA_Salinity</th>\n",
+       "      <th>QA_pH</th>\n",
+       "      <th>QA_Turbidity</th>\n",
+       "      <th>QA_DO</th>\n",
+       "      <th>QA_Sediment</th>\n",
+       "      <th>QA_Fecal_Coliform</th>\n",
        "      <th>QA_Temperature</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -1987,7 +1990,7 @@
        "      <td>EST</td>\n",
        "      <td>CRWA-ROB</td>\n",
        "      <td>STORET-591631481</td>\n",
-       "      <td>130809111433.0</td>\n",
+       "      <td>130809111433</td>\n",
        "      <td>NaN</td>\n",
        "      <td>...</td>\n",
        "      <td>NaN</td>\n",
@@ -2227,57 +2230,57 @@
        "575732                    NaN                            NaN   \n",
        "575733                    NaN                            NaN   \n",
        "\n",
-       "       MonitoringLocationIdentifier   ResultIdentifier  DataLoggerLine  \\\n",
-       "0                   BRC-C-02-02-020  STORET-1039097035             NaN   \n",
-       "1                      OARS-CND-161   STORET-838568413             NaN   \n",
-       "2                      OARS-SUD-064   STORET-838568309             NaN   \n",
-       "3                          CRWA-ROB   STORET-591631481  130809111433.0   \n",
-       "4                         WTGHA-M41  STORET-1041401688             NaN   \n",
-       "...                             ...                ...             ...   \n",
-       "575729     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598867             NaN   \n",
-       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866             NaN   \n",
-       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862             NaN   \n",
-       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863             NaN   \n",
-       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462             NaN   \n",
+       "       MonitoringLocationIdentifier   ResultIdentifier DataLoggerLine  \\\n",
+       "0                   BRC-C-02-02-020  STORET-1039097035            NaN   \n",
+       "1                      OARS-CND-161   STORET-838568413            NaN   \n",
+       "2                      OARS-SUD-064   STORET-838568309            NaN   \n",
+       "3                          CRWA-ROB   STORET-591631481   130809111433   \n",
+       "4                         WTGHA-M41  STORET-1041401688            NaN   \n",
+       "...                             ...                ...            ...   \n",
+       "575729     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598867            NaN   \n",
+       "575730     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598866            NaN   \n",
+       "575731     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598862            NaN   \n",
+       "575732     11NPSWRD_WQX-CACO_DUCK_W   STORET-740598863            NaN   \n",
+       "575733    11NPSWRD_WQX-CACO_GREAT_W   STORET-740649462            NaN   \n",
        "\n",
-       "       ResultDetectionConditionText  ... QA_TP_Phosphorus QA_TDP_Phosphorus  \\\n",
-       "0                               NaN  ...              NaN               NaN   \n",
-       "1                               NaN  ...              NaN               NaN   \n",
-       "2                               NaN  ...              NaN               NaN   \n",
-       "3                               NaN  ...              NaN               NaN   \n",
-       "4                               NaN  ...              NaN               NaN   \n",
-       "...                             ...  ...              ...               ...   \n",
-       "575729                          NaN  ...              NaN               NaN   \n",
-       "575730                          NaN  ...              NaN               NaN   \n",
-       "575731                          NaN  ...              NaN               NaN   \n",
-       "575732                          NaN  ...              NaN               NaN   \n",
-       "575733                          NaN  ...              NaN               NaN   \n",
+       "       ResultDetectionConditionText  ... QA_Other_Phosphorus QA_Chlorophyll  \\\n",
+       "0                               NaN  ...                 NaN            NaN   \n",
+       "1                               NaN  ...                 NaN            NaN   \n",
+       "2                               NaN  ...                 NaN            NaN   \n",
+       "3                               NaN  ...                 NaN            NaN   \n",
+       "4                               NaN  ...                 NaN            NaN   \n",
+       "...                             ...  ...                 ...            ...   \n",
+       "575729                          NaN  ...                 NaN            NaN   \n",
+       "575730                          NaN  ...                 NaN            NaN   \n",
+       "575731                          NaN  ...                 NaN            NaN   \n",
+       "575732                          NaN  ...                 NaN            NaN   \n",
+       "575733                          NaN  ...                 NaN            NaN   \n",
        "\n",
-       "       QA_Other_Phosphorus QA_Conductivity QA_Secchi QA_Fecal_Coliform  \\\n",
-       "0                      NaN             NaN       NaN               NaN   \n",
-       "1                      NaN             NaN       NaN               NaN   \n",
-       "2                      NaN             NaN       NaN               NaN   \n",
-       "3                      NaN             NaN       NaN               NaN   \n",
-       "4                      NaN             NaN       NaN               NaN   \n",
-       "...                    ...             ...       ...               ...   \n",
-       "575729                 NaN             NaN       NaN               NaN   \n",
-       "575730                 NaN             NaN       NaN               NaN   \n",
-       "575731                 NaN             NaN       NaN               NaN   \n",
-       "575732                 NaN             NaN       NaN               NaN   \n",
-       "575733                 NaN             NaN       NaN               NaN   \n",
+       "       QA_E_coli QA_Salinity QA_pH QA_Turbidity QA_DO QA_Sediment  \\\n",
+       "0            NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "1            NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "2            NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "3            NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "4            NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "...          ...         ...   ...          ...   ...         ...   \n",
+       "575729       NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "575730       NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "575731       NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "575732       NaN         NaN   NaN          NaN   NaN         NaN   \n",
+       "575733       NaN         NaN   NaN          NaN   NaN         NaN   \n",
        "\n",
-       "       QA_Sediment QA_Nitrogen QA_E_coli QA_Temperature  \n",
-       "0              NaN         NaN       NaN            NaN  \n",
-       "1              NaN         NaN       NaN            NaN  \n",
-       "2              NaN         NaN       NaN            NaN  \n",
-       "3              NaN         NaN       NaN            NaN  \n",
-       "4              NaN         NaN       NaN            NaN  \n",
-       "...            ...         ...       ...            ...  \n",
-       "575729         NaN         NaN       NaN            NaN  \n",
-       "575730         NaN         NaN       NaN            NaN  \n",
-       "575731         NaN         NaN       NaN            NaN  \n",
-       "575732         NaN         NaN       NaN            NaN  \n",
-       "575733         NaN         NaN       NaN            NaN  \n",
+       "       QA_Fecal_Coliform QA_Temperature  \n",
+       "0                    NaN            NaN  \n",
+       "1                    NaN            NaN  \n",
+       "2                    NaN            NaN  \n",
+       "3                    NaN            NaN  \n",
+       "4                    NaN            NaN  \n",
+       "...                  ...            ...  \n",
+       "575729               NaN            NaN  \n",
+       "575730               NaN            NaN  \n",
+       "575731               NaN            NaN  \n",
+       "575732               NaN            NaN  \n",
+       "575733               NaN            NaN  \n",
        "\n",
        "[520571 rows x 115 columns]"
       ]
@@ -2298,10 +2301,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:54:59.820536Z",
-     "iopub.status.busy": "2026-04-05T03:54:59.820296Z",
-     "iopub.status.idle": "2026-04-05T03:55:00.592032Z",
-     "shell.execute_reply": "2026-04-05T03:55:00.591352Z"
+     "iopub.execute_input": "2026-04-15T16:34:28.209170Z",
+     "iopub.status.busy": "2026-04-15T16:34:28.208932Z",
+     "iopub.status.idle": "2026-04-15T16:34:28.913929Z",
+     "shell.execute_reply": "2026-04-15T16:34:28.913232Z"
     }
    },
    "outputs": [],
@@ -2315,10 +2318,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:00.594335Z",
-     "iopub.status.busy": "2026-04-05T03:55:00.594096Z",
-     "iopub.status.idle": "2026-04-05T03:55:01.099720Z",
-     "shell.execute_reply": "2026-04-05T03:55:01.098914Z"
+     "iopub.execute_input": "2026-04-15T16:34:28.916258Z",
+     "iopub.status.busy": "2026-04-15T16:34:28.916031Z",
+     "iopub.status.idle": "2026-04-15T16:34:29.425743Z",
+     "shell.execute_reply": "2026-04-15T16:34:29.424997Z"
     }
    },
    "outputs": [],
@@ -2339,10 +2342,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:01.102081Z",
-     "iopub.status.busy": "2026-04-05T03:55:01.101849Z",
-     "iopub.status.idle": "2026-04-05T03:55:51.150502Z",
-     "shell.execute_reply": "2026-04-05T03:55:51.149778Z"
+     "iopub.execute_input": "2026-04-15T16:34:29.428081Z",
+     "iopub.status.busy": "2026-04-15T16:34:29.427879Z",
+     "iopub.status.idle": "2026-04-15T16:35:12.834596Z",
+     "shell.execute_reply": "2026-04-15T16:35:12.834007Z"
     }
    },
    "outputs": [],

--- a/demos/Harmonize_Pensacola_Detailed.ipynb
+++ b/demos/Harmonize_Pensacola_Detailed.ipynb
@@ -57,10 +57,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:56.325548Z",
-     "iopub.status.busy": "2026-04-05T03:55:56.325290Z",
-     "iopub.status.idle": "2026-04-05T03:55:56.331844Z",
-     "shell.execute_reply": "2026-04-05T03:55:56.331285Z"
+     "iopub.execute_input": "2026-04-15T16:35:17.747019Z",
+     "iopub.status.busy": "2026-04-15T16:35:17.746745Z",
+     "iopub.status.idle": "2026-04-15T16:35:17.752944Z",
+     "shell.execute_reply": "2026-04-15T16:35:17.752378Z"
     }
    },
    "outputs": [],
@@ -79,10 +79,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:56.333732Z",
-     "iopub.status.busy": "2026-04-05T03:55:56.333557Z",
-     "iopub.status.idle": "2026-04-05T03:55:56.962104Z",
-     "shell.execute_reply": "2026-04-05T03:55:56.961468Z"
+     "iopub.execute_input": "2026-04-15T16:35:17.754885Z",
+     "iopub.status.busy": "2026-04-15T16:35:17.754695Z",
+     "iopub.status.idle": "2026-04-15T16:35:18.333219Z",
+     "shell.execute_reply": "2026-04-15T16:35:18.332689Z"
     }
    },
    "outputs": [],
@@ -107,10 +107,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:56.964617Z",
-     "iopub.status.busy": "2026-04-05T03:55:56.964348Z",
-     "iopub.status.idle": "2026-04-05T03:55:57.815732Z",
-     "shell.execute_reply": "2026-04-05T03:55:57.814977Z"
+     "iopub.execute_input": "2026-04-15T16:35:18.335604Z",
+     "iopub.status.busy": "2026-04-15T16:35:18.335354Z",
+     "iopub.status.idle": "2026-04-15T16:35:18.929892Z",
+     "shell.execute_reply": "2026-04-15T16:35:18.929277Z"
     }
    },
    "outputs": [
@@ -147,10 +147,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:57.826914Z",
-     "iopub.status.busy": "2026-04-05T03:55:57.826625Z",
-     "iopub.status.idle": "2026-04-05T03:55:57.830197Z",
-     "shell.execute_reply": "2026-04-05T03:55:57.829652Z"
+     "iopub.execute_input": "2026-04-15T16:35:18.946426Z",
+     "iopub.status.busy": "2026-04-15T16:35:18.946141Z",
+     "iopub.status.idle": "2026-04-15T16:35:18.949621Z",
+     "shell.execute_reply": "2026-04-15T16:35:18.949100Z"
     }
    },
    "outputs": [],
@@ -168,10 +168,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:57.832118Z",
-     "iopub.status.busy": "2026-04-05T03:55:57.831912Z",
-     "iopub.status.idle": "2026-04-05T03:55:57.835699Z",
-     "shell.execute_reply": "2026-04-05T03:55:57.835129Z"
+     "iopub.execute_input": "2026-04-15T16:35:18.951370Z",
+     "iopub.status.busy": "2026-04-15T16:35:18.951183Z",
+     "iopub.status.idle": "2026-04-15T16:35:18.954774Z",
+     "shell.execute_reply": "2026-04-15T16:35:18.954198Z"
     }
    },
    "outputs": [],
@@ -199,10 +199,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:55:57.837490Z",
-     "iopub.status.busy": "2026-04-05T03:55:57.837262Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.021557Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.020872Z"
+     "iopub.execute_input": "2026-04-15T16:35:18.956483Z",
+     "iopub.status.busy": "2026-04-15T16:35:18.956299Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.259313Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.258757Z"
     }
    },
    "outputs": [],
@@ -216,10 +216,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.023884Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.023698Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.027843Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.027148Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.261717Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.261536Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.265397Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.264803Z"
     }
    },
    "outputs": [
@@ -244,10 +244,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.029699Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.029518Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.045686Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.045085Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.267326Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.267137Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.281699Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.281194Z"
     }
    },
    "outputs": [
@@ -517,10 +517,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.047762Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.047555Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.053325Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.052767Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.283418Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.283247Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.288169Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.287665Z"
     }
    },
    "outputs": [
@@ -548,10 +548,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.055413Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.055184Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.203757Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.202979Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.289868Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.289684Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.424847Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.424147Z"
     }
    },
    "outputs": [
@@ -582,10 +582,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.205768Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.205574Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.244992Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.244359Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.426701Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.426523Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.465498Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.464957Z"
     }
    },
    "outputs": [],
@@ -598,10 +598,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.247122Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.246935Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.251098Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.250544Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.467376Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.467191Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.470731Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.470265Z"
     }
    },
    "outputs": [
@@ -626,10 +626,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.252830Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.252647Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.258688Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.258104Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.472459Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.472286Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.477632Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.477036Z"
     }
    },
    "outputs": [
@@ -659,17 +659,17 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.260502Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.260302Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.264158Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.263587Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.479332Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.479157Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.482906Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.482307Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<geopandas.array.GeometryDtype at 0x7f7d667dd160>"
+       "<geopandas.array.GeometryDtype at 0x7f0a0d800cd0>"
       ]
      },
      "execution_count": 14,
@@ -687,10 +687,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.265999Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.265803Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.271794Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.271088Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.484560Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.484389Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.489403Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.488810Z"
     }
    },
    "outputs": [
@@ -722,10 +722,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.273647Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.273444Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.454075Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.453441Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.491271Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.491056Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.653416Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.652855Z"
     }
    },
    "outputs": [
@@ -760,10 +760,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.456034Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.455841Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.480351Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.479692Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.655305Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.655100Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.680419Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.679777Z"
     }
    },
    "outputs": [],
@@ -777,10 +777,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.482697Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.482494Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.618871Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.618184Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.682278Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.682056Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.804514Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.803876Z"
     }
    },
    "outputs": [
@@ -815,10 +815,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.620826Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.620636Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.624602Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.624045Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.806414Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.806236Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.809997Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.809507Z"
     }
    },
    "outputs": [
@@ -843,10 +843,10 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.626405Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.626197Z",
-     "iopub.status.idle": "2026-04-05T03:56:09.628680Z",
-     "shell.execute_reply": "2026-04-05T03:56:09.628106Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.811656Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.811493Z",
+     "iopub.status.idle": "2026-04-15T16:35:31.813899Z",
+     "shell.execute_reply": "2026-04-15T16:35:31.813409Z"
     }
    },
    "outputs": [],
@@ -869,22 +869,13 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T03:56:09.630577Z",
-     "iopub.status.busy": "2026-04-05T03:56:09.630378Z",
-     "iopub.status.idle": "2026-04-05T04:04:51.033039Z",
-     "shell.execute_reply": "2026-04-05T04:04:51.032387Z"
+     "iopub.execute_input": "2026-04-15T16:35:31.815619Z",
+     "iopub.status.busy": "2026-04-15T16:35:31.815444Z",
+     "iopub.status.idle": "2026-04-15T16:44:09.896631Z",
+     "shell.execute_reply": "2026-04-15T16:44:09.896052Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:153: DtypeWarning: Columns (10,13,15,17,19,20,21,22,23,28,31,33,34,36,58,60,61,64,65,69,70,71,72,73) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now query for results\n",
     "query['dataProfile'] = 'narrowResult'\n",
@@ -896,10 +887,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:51.035427Z",
-     "iopub.status.busy": "2026-04-05T04:04:51.035179Z",
-     "iopub.status.idle": "2026-04-05T04:04:51.209305Z",
-     "shell.execute_reply": "2026-04-05T04:04:51.208636Z"
+     "iopub.execute_input": "2026-04-15T16:44:09.899290Z",
+     "iopub.status.busy": "2026-04-15T16:44:09.899042Z",
+     "iopub.status.idle": "2026-04-15T16:44:10.065278Z",
+     "shell.execute_reply": "2026-04-15T16:44:10.064642Z"
     }
    },
    "outputs": [
@@ -1379,10 +1370,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:51.211284Z",
-     "iopub.status.busy": "2026-04-05T04:04:51.211089Z",
-     "iopub.status.idle": "2026-04-05T04:04:52.026480Z",
-     "shell.execute_reply": "2026-04-05T04:04:52.025703Z"
+     "iopub.execute_input": "2026-04-15T16:44:10.067215Z",
+     "iopub.status.busy": "2026-04-15T16:44:10.066997Z",
+     "iopub.status.idle": "2026-04-15T16:44:10.856851Z",
+     "shell.execute_reply": "2026-04-15T16:44:10.856144Z"
     }
    },
    "outputs": [
@@ -1433,10 +1424,10 @@
    "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:52.028809Z",
-     "iopub.status.busy": "2026-04-05T04:04:52.028534Z",
-     "iopub.status.idle": "2026-04-05T04:04:52.031116Z",
-     "shell.execute_reply": "2026-04-05T04:04:52.030602Z"
+     "iopub.execute_input": "2026-04-15T16:44:10.859052Z",
+     "iopub.status.busy": "2026-04-15T16:44:10.858782Z",
+     "iopub.status.idle": "2026-04-15T16:44:10.861297Z",
+     "shell.execute_reply": "2026-04-15T16:44:10.860826Z"
     }
    },
    "outputs": [],
@@ -1458,10 +1449,10 @@
    "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:52.033014Z",
-     "iopub.status.busy": "2026-04-05T04:04:52.032830Z",
-     "iopub.status.idle": "2026-04-05T04:04:53.732227Z",
-     "shell.execute_reply": "2026-04-05T04:04:53.731598Z"
+     "iopub.execute_input": "2026-04-15T16:44:10.863003Z",
+     "iopub.status.busy": "2026-04-15T16:44:10.862833Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.327141Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.326500Z"
     },
     "scrolled": true
    },
@@ -1486,7 +1477,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(2.0, 'meter')> <Quantity(0.94, 'meter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(2.0, 'meter')> <Quantity(0.94, 'meter')>\n",
       " <Quantity(0.6, 'meter')> ... <Quantity(1.67, 'meter')>\n",
       " <Quantity(0.3048, 'meter')> <Quantity(0.11, 'meter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1542,10 +1533,10 @@
    "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:53.734522Z",
-     "iopub.status.busy": "2026-04-05T04:04:53.734227Z",
-     "iopub.status.idle": "2026-04-05T04:04:53.785556Z",
-     "shell.execute_reply": "2026-04-05T04:04:53.784878Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.329158Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.328948Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.378659Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.378011Z"
     }
    },
    "outputs": [
@@ -1730,10 +1721,10 @@
    "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:53.787535Z",
-     "iopub.status.busy": "2026-04-05T04:04:53.787294Z",
-     "iopub.status.idle": "2026-04-05T04:04:53.805063Z",
-     "shell.execute_reply": "2026-04-05T04:04:53.804342Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.380623Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.380420Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.397487Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.396908Z"
     }
    },
    "outputs": [
@@ -1929,10 +1920,10 @@
    "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:53.806938Z",
-     "iopub.status.busy": "2026-04-05T04:04:53.806745Z",
-     "iopub.status.idle": "2026-04-05T04:04:53.819935Z",
-     "shell.execute_reply": "2026-04-05T04:04:53.819408Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.399374Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.399175Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.412681Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.412219Z"
     }
    },
    "outputs": [
@@ -1957,10 +1948,10 @@
    "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:53.821749Z",
-     "iopub.status.busy": "2026-04-05T04:04:53.821567Z",
-     "iopub.status.idle": "2026-04-05T04:04:53.837831Z",
-     "shell.execute_reply": "2026-04-05T04:04:53.837265Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.414530Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.414344Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.430075Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.429547Z"
     }
    },
    "outputs": [
@@ -2163,10 +2154,10 @@
    "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:53.839684Z",
-     "iopub.status.busy": "2026-04-05T04:04:53.839506Z",
-     "iopub.status.idle": "2026-04-05T04:04:53.861760Z",
-     "shell.execute_reply": "2026-04-05T04:04:53.861144Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.431887Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.431705Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.453281Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.452726Z"
     }
    },
    "outputs": [
@@ -2300,10 +2291,10 @@
    "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:53.863576Z",
-     "iopub.status.busy": "2026-04-05T04:04:53.863395Z",
-     "iopub.status.idle": "2026-04-05T04:04:54.118026Z",
-     "shell.execute_reply": "2026-04-05T04:04:54.117358Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.455153Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.454937Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.702057Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.701450Z"
     }
    },
    "outputs": [
@@ -2339,10 +2330,10 @@
    "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:54.119955Z",
-     "iopub.status.busy": "2026-04-05T04:04:54.119764Z",
-     "iopub.status.idle": "2026-04-05T04:04:54.318461Z",
-     "shell.execute_reply": "2026-04-05T04:04:54.317742Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.704191Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.703960Z",
+     "iopub.status.idle": "2026-04-15T16:44:12.885644Z",
+     "shell.execute_reply": "2026-04-15T16:44:12.885019Z"
     }
    },
    "outputs": [
@@ -2392,10 +2383,10 @@
    "execution_count": 33,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:54.320543Z",
-     "iopub.status.busy": "2026-04-05T04:04:54.320348Z",
-     "iopub.status.idle": "2026-04-05T04:04:56.964031Z",
-     "shell.execute_reply": "2026-04-05T04:04:56.963392Z"
+     "iopub.execute_input": "2026-04-15T16:44:12.887681Z",
+     "iopub.status.busy": "2026-04-15T16:44:12.887495Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.221334Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.220681Z"
     }
    },
    "outputs": [
@@ -2411,7 +2402,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(26.0555556, 'degree_Celsius')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(26.0555556, 'degree_Celsius')>\n",
       " <Quantity(12.35, 'degree_Celsius')> <Quantity(23.0, 'degree_Celsius')>\n",
       " ... <Quantity(25.0, 'degree_Celsius')> <Quantity(24.0, 'degree_Celsius')>\n",
       " <Quantity(20.5, 'degree_Celsius')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
@@ -2459,10 +2450,10 @@
    "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:56.966143Z",
-     "iopub.status.busy": "2026-04-05T04:04:56.965948Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.020666Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.019888Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.223326Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.223127Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.276400Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.275749Z"
     }
    },
    "outputs": [
@@ -2667,10 +2658,10 @@
    "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.022804Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.022577Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.044306Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.043620Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.278353Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.278160Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.300176Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.299609Z"
     }
    },
    "outputs": [
@@ -2883,10 +2874,10 @@
    "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.046215Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.046016Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.063115Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.062568Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.301956Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.301760Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.319392Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.318792Z"
     }
    },
    "outputs": [
@@ -2911,10 +2902,10 @@
    "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.064945Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.064765Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.085968Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.085245Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.321301Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.321081Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.342018Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.341496Z"
     }
    },
    "outputs": [
@@ -2999,10 +2990,10 @@
    "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.087856Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.087654Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.152866Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.152193Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.343764Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.343582Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.409854Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.409228Z"
     }
    },
    "outputs": [
@@ -3136,10 +3127,10 @@
    "execution_count": 39,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.154809Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.154620Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.375041Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.374320Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.411684Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.411504Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.617258Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.616659Z"
     }
    },
    "outputs": [
@@ -3175,10 +3166,10 @@
    "execution_count": 40,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.377133Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.376932Z",
-     "iopub.status.idle": "2026-04-05T04:04:57.666321Z",
-     "shell.execute_reply": "2026-04-05T04:04:57.665581Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.619311Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.619097Z",
+     "iopub.status.idle": "2026-04-15T16:44:15.899396Z",
+     "shell.execute_reply": "2026-04-15T16:44:15.898711Z"
     }
    },
    "outputs": [
@@ -3221,10 +3212,10 @@
    "execution_count": 41,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:04:57.668413Z",
-     "iopub.status.busy": "2026-04-05T04:04:57.668194Z",
-     "iopub.status.idle": "2026-04-05T04:05:10.093426Z",
-     "shell.execute_reply": "2026-04-05T04:05:10.092671Z"
+     "iopub.execute_input": "2026-04-15T16:44:15.901535Z",
+     "iopub.status.busy": "2026-04-15T16:44:15.901331Z",
+     "iopub.status.idle": "2026-04-15T16:44:25.926332Z",
+     "shell.execute_reply": "2026-04-15T16:44:25.925650Z"
     }
    },
    "outputs": [
@@ -3240,7 +3231,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(6.3, 'milligram / liter')> <Quantity(4.5, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(6.3, 'milligram / liter')> <Quantity(4.5, 'milligram / liter')>\n",
       " <Quantity(6.64, 'milligram / liter')> ...\n",
       " <Quantity(7.9, 'milligram / liter')> <Quantity(6.1, 'milligram / liter')>\n",
       " <Quantity(7.1, 'milligram / liter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
@@ -3265,10 +3256,10 @@
    "execution_count": 42,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:10.095460Z",
-     "iopub.status.busy": "2026-04-05T04:05:10.095218Z",
-     "iopub.status.idle": "2026-04-05T04:05:10.147505Z",
-     "shell.execute_reply": "2026-04-05T04:05:10.146836Z"
+     "iopub.execute_input": "2026-04-15T16:44:25.928407Z",
+     "iopub.status.busy": "2026-04-15T16:44:25.928200Z",
+     "iopub.status.idle": "2026-04-15T16:44:25.978946Z",
+     "shell.execute_reply": "2026-04-15T16:44:25.978317Z"
     }
    },
    "outputs": [
@@ -3441,10 +3432,10 @@
    "execution_count": 43,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:10.149583Z",
-     "iopub.status.busy": "2026-04-05T04:05:10.149360Z",
-     "iopub.status.idle": "2026-04-05T04:05:10.165489Z",
-     "shell.execute_reply": "2026-04-05T04:05:10.164891Z"
+     "iopub.execute_input": "2026-04-15T16:44:25.981026Z",
+     "iopub.status.busy": "2026-04-15T16:44:25.980827Z",
+     "iopub.status.idle": "2026-04-15T16:44:25.996458Z",
+     "shell.execute_reply": "2026-04-15T16:44:25.995910Z"
     }
    },
    "outputs": [
@@ -3621,10 +3612,10 @@
    "execution_count": 44,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:10.167521Z",
-     "iopub.status.busy": "2026-04-05T04:05:10.167308Z",
-     "iopub.status.idle": "2026-04-05T04:05:10.223717Z",
-     "shell.execute_reply": "2026-04-05T04:05:10.223087Z"
+     "iopub.execute_input": "2026-04-15T16:44:25.998256Z",
+     "iopub.status.busy": "2026-04-15T16:44:25.998047Z",
+     "iopub.status.idle": "2026-04-15T16:44:26.055379Z",
+     "shell.execute_reply": "2026-04-15T16:44:26.054726Z"
     }
    },
    "outputs": [
@@ -3758,10 +3749,10 @@
    "execution_count": 45,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:10.225637Z",
-     "iopub.status.busy": "2026-04-05T04:05:10.225453Z",
-     "iopub.status.idle": "2026-04-05T04:05:10.444507Z",
-     "shell.execute_reply": "2026-04-05T04:05:10.443757Z"
+     "iopub.execute_input": "2026-04-15T16:44:26.057368Z",
+     "iopub.status.busy": "2026-04-15T16:44:26.057190Z",
+     "iopub.status.idle": "2026-04-15T16:44:26.263919Z",
+     "shell.execute_reply": "2026-04-15T16:44:26.263289Z"
     }
    },
    "outputs": [
@@ -3797,10 +3788,10 @@
    "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:10.446476Z",
-     "iopub.status.busy": "2026-04-05T04:05:10.446260Z",
-     "iopub.status.idle": "2026-04-05T04:05:10.722511Z",
-     "shell.execute_reply": "2026-04-05T04:05:10.721797Z"
+     "iopub.execute_input": "2026-04-15T16:44:26.265878Z",
+     "iopub.status.busy": "2026-04-15T16:44:26.265686Z",
+     "iopub.status.idle": "2026-04-15T16:44:26.526839Z",
+     "shell.execute_reply": "2026-04-15T16:44:26.526167Z"
     }
    },
    "outputs": [
@@ -3843,10 +3834,10 @@
    "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:10.724612Z",
-     "iopub.status.busy": "2026-04-05T04:05:10.724420Z",
-     "iopub.status.idle": "2026-04-05T04:05:12.958980Z",
-     "shell.execute_reply": "2026-04-05T04:05:12.958302Z"
+     "iopub.execute_input": "2026-04-15T16:44:26.528798Z",
+     "iopub.status.busy": "2026-04-15T16:44:26.528617Z",
+     "iopub.status.idle": "2026-04-15T16:44:28.571399Z",
+     "shell.execute_reply": "2026-04-15T16:44:28.570771Z"
     }
    },
    "outputs": [
@@ -3862,7 +3853,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.29, 'dimensionless')> <Quantity(8.09, 'dimensionless')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.29, 'dimensionless')> <Quantity(8.09, 'dimensionless')>\n",
       " <Quantity(7.45, 'dimensionless')> ... <Quantity(8.27, 'dimensionless')>\n",
       " <Quantity(8.47, 'dimensionless')> <Quantity(8.48, 'dimensionless')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -3915,10 +3906,10 @@
    "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:12.960986Z",
-     "iopub.status.busy": "2026-04-05T04:05:12.960798Z",
-     "iopub.status.idle": "2026-04-05T04:05:13.007257Z",
-     "shell.execute_reply": "2026-04-05T04:05:13.006588Z"
+     "iopub.execute_input": "2026-04-15T16:44:28.573370Z",
+     "iopub.status.busy": "2026-04-15T16:44:28.573185Z",
+     "iopub.status.idle": "2026-04-15T16:44:28.618525Z",
+     "shell.execute_reply": "2026-04-15T16:44:28.617854Z"
     }
    },
    "outputs": [
@@ -4090,10 +4081,10 @@
    "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:13.009442Z",
-     "iopub.status.busy": "2026-04-05T04:05:13.009217Z",
-     "iopub.status.idle": "2026-04-05T04:05:22.812269Z",
-     "shell.execute_reply": "2026-04-05T04:05:22.811608Z"
+     "iopub.execute_input": "2026-04-15T16:44:28.620664Z",
+     "iopub.status.busy": "2026-04-15T16:44:28.620459Z",
+     "iopub.status.idle": "2026-04-15T16:44:36.433526Z",
+     "shell.execute_reply": "2026-04-15T16:44:36.432821Z"
     }
    },
    "outputs": [
@@ -4109,7 +4100,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(1.012, 'Practical_Salinity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(1.012, 'Practical_Salinity_Units')>\n",
       " <Quantity(18.9, 'Practical_Salinity_Units')>\n",
       " <Quantity(25.0, 'Practical_Salinity_Units')> ...\n",
       " <Quantity(2.11, 'Practical_Salinity_Units')>\n",
@@ -4158,10 +4149,10 @@
    "execution_count": 50,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:22.814308Z",
-     "iopub.status.busy": "2026-04-05T04:05:22.814117Z",
-     "iopub.status.idle": "2026-04-05T04:05:22.863289Z",
-     "shell.execute_reply": "2026-04-05T04:05:22.862562Z"
+     "iopub.execute_input": "2026-04-15T16:44:36.435577Z",
+     "iopub.status.busy": "2026-04-15T16:44:36.435369Z",
+     "iopub.status.idle": "2026-04-15T16:44:36.486246Z",
+     "shell.execute_reply": "2026-04-15T16:44:36.485565Z"
     }
    },
    "outputs": [
@@ -4327,10 +4318,10 @@
    "execution_count": 51,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:22.865539Z",
-     "iopub.status.busy": "2026-04-05T04:05:22.865284Z",
-     "iopub.status.idle": "2026-04-05T04:05:26.325025Z",
-     "shell.execute_reply": "2026-04-05T04:05:26.324233Z"
+     "iopub.execute_input": "2026-04-15T16:44:36.488318Z",
+     "iopub.status.busy": "2026-04-15T16:44:36.488078Z",
+     "iopub.status.idle": "2026-04-15T16:44:39.213231Z",
+     "shell.execute_reply": "2026-04-15T16:44:39.212625Z"
     }
    },
    "outputs": [
@@ -4365,7 +4356,7 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:395: UserWarning: WARNING: 'cm3/g' UNDEFINED UNIT for Nitrogen\n",
       "  warn(\"WARNING: \" + problem)\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.3, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.3, 'milligram / liter')>\n",
       " <Quantity(0.36, 'milligram / liter')>\n",
       " <Quantity(0.33875, 'milligram / liter')>\n",
       " <Quantity(0.53125, 'milligram / liter')>\n",
@@ -4531,10 +4522,10 @@
    "execution_count": 52,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:26.327087Z",
-     "iopub.status.busy": "2026-04-05T04:05:26.326878Z",
-     "iopub.status.idle": "2026-04-05T04:05:26.368531Z",
-     "shell.execute_reply": "2026-04-05T04:05:26.367786Z"
+     "iopub.execute_input": "2026-04-15T16:44:39.215121Z",
+     "iopub.status.busy": "2026-04-15T16:44:39.214909Z",
+     "iopub.status.idle": "2026-04-15T16:44:39.256243Z",
+     "shell.execute_reply": "2026-04-15T16:44:39.255598Z"
     }
    },
    "outputs": [
@@ -4700,10 +4691,10 @@
    "execution_count": 53,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:26.370729Z",
-     "iopub.status.busy": "2026-04-05T04:05:26.370541Z",
-     "iopub.status.idle": "2026-04-05T04:05:28.202673Z",
-     "shell.execute_reply": "2026-04-05T04:05:28.202052Z"
+     "iopub.execute_input": "2026-04-15T16:44:39.258177Z",
+     "iopub.status.busy": "2026-04-15T16:44:39.257963Z",
+     "iopub.status.idle": "2026-04-15T16:44:40.897098Z",
+     "shell.execute_reply": "2026-04-15T16:44:40.896453Z"
     }
    },
    "outputs": [
@@ -4719,7 +4710,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(19204.2, 'microsiemens / centimeter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(19204.2, 'microsiemens / centimeter')>\n",
       " <Quantity(222.3, 'microsiemens / centimeter')>\n",
       " <Quantity(102.8, 'microsiemens / centimeter')> ...\n",
       " <Quantity(110.0, 'microsiemens / centimeter')>\n",
@@ -4768,10 +4759,10 @@
    "execution_count": 54,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:28.204618Z",
-     "iopub.status.busy": "2026-04-05T04:05:28.204429Z",
-     "iopub.status.idle": "2026-04-05T04:05:28.246201Z",
-     "shell.execute_reply": "2026-04-05T04:05:28.245519Z"
+     "iopub.execute_input": "2026-04-15T16:44:40.898999Z",
+     "iopub.status.busy": "2026-04-15T16:44:40.898801Z",
+     "iopub.status.idle": "2026-04-15T16:44:40.939346Z",
+     "shell.execute_reply": "2026-04-15T16:44:40.938707Z"
     }
    },
    "outputs": [
@@ -4937,10 +4928,10 @@
    "execution_count": 55,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:28.248298Z",
-     "iopub.status.busy": "2026-04-05T04:05:28.248108Z",
-     "iopub.status.idle": "2026-04-05T04:05:30.904901Z",
-     "shell.execute_reply": "2026-04-05T04:05:30.904162Z"
+     "iopub.execute_input": "2026-04-15T16:44:40.941271Z",
+     "iopub.status.busy": "2026-04-15T16:44:40.941050Z",
+     "iopub.status.idle": "2026-04-15T16:44:43.336428Z",
+     "shell.execute_reply": "2026-04-15T16:44:43.335768Z"
     }
    },
    "outputs": [
@@ -4964,7 +4955,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.0023, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.0023, 'milligram / liter')>\n",
       " <Quantity(0.0029, 'milligram / liter')>\n",
       " <Quantity(0.0041, 'milligram / liter')> ...\n",
       " <Quantity(0.00672003521, 'milligram / liter')>\n",
@@ -5013,10 +5004,10 @@
    "execution_count": 56,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:30.906969Z",
-     "iopub.status.busy": "2026-04-05T04:05:30.906779Z",
-     "iopub.status.idle": "2026-04-05T04:05:30.949019Z",
-     "shell.execute_reply": "2026-04-05T04:05:30.948360Z"
+     "iopub.execute_input": "2026-04-15T16:44:43.338406Z",
+     "iopub.status.busy": "2026-04-15T16:44:43.338210Z",
+     "iopub.status.idle": "2026-04-15T16:44:43.379807Z",
+     "shell.execute_reply": "2026-04-15T16:44:43.379174Z"
     }
    },
    "outputs": [
@@ -5195,10 +5186,10 @@
    "execution_count": 57,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:30.951099Z",
-     "iopub.status.busy": "2026-04-05T04:05:30.950910Z",
-     "iopub.status.idle": "2026-04-05T04:05:33.893313Z",
-     "shell.execute_reply": "2026-04-05T04:05:33.892506Z"
+     "iopub.execute_input": "2026-04-15T16:44:43.381738Z",
+     "iopub.status.busy": "2026-04-15T16:44:43.381540Z",
+     "iopub.status.idle": "2026-04-15T16:44:45.982228Z",
+     "shell.execute_reply": "2026-04-15T16:44:45.981576Z"
     }
    },
    "outputs": [
@@ -5214,7 +5205,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(2.6, 'milligram / liter')> <Quantity(3.9, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(2.6, 'milligram / liter')> <Quantity(3.9, 'milligram / liter')>\n",
       " <Quantity(5.2, 'milligram / liter')> ...\n",
       " <Quantity(1.7, 'milligram / liter')> <Quantity(1.5, 'milligram / liter')>\n",
       " <Quantity(4.536, 'milligram / liter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
@@ -5261,10 +5252,10 @@
    "execution_count": 58,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:33.895361Z",
-     "iopub.status.busy": "2026-04-05T04:05:33.895137Z",
-     "iopub.status.idle": "2026-04-05T04:05:33.938040Z",
-     "shell.execute_reply": "2026-04-05T04:05:33.937342Z"
+     "iopub.execute_input": "2026-04-15T16:44:45.984124Z",
+     "iopub.status.busy": "2026-04-15T16:44:45.983912Z",
+     "iopub.status.idle": "2026-04-15T16:44:46.025840Z",
+     "shell.execute_reply": "2026-04-15T16:44:46.025201Z"
     }
    },
    "outputs": [
@@ -5443,10 +5434,10 @@
    "execution_count": 59,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:33.940056Z",
-     "iopub.status.busy": "2026-04-05T04:05:33.939867Z",
-     "iopub.status.idle": "2026-04-05T04:05:38.152478Z",
-     "shell.execute_reply": "2026-04-05T04:05:38.151853Z"
+     "iopub.execute_input": "2026-04-15T16:44:46.027938Z",
+     "iopub.status.busy": "2026-04-15T16:44:46.027729Z",
+     "iopub.status.idle": "2026-04-15T16:44:49.679883Z",
+     "shell.execute_reply": "2026-04-15T16:44:49.679250Z"
     }
    },
    "outputs": [
@@ -5462,7 +5453,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(380.4523, 'Nephelometric_Turbidity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(380.4523, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(0.0, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(190.2023, 'Nephelometric_Turbidity_Units')> ...\n",
       " <Quantity(1.2, 'Nephelometric_Turbidity_Units')>\n",
@@ -5511,10 +5502,10 @@
    "execution_count": 60,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:38.154436Z",
-     "iopub.status.busy": "2026-04-05T04:05:38.154221Z",
-     "iopub.status.idle": "2026-04-05T04:05:38.199280Z",
-     "shell.execute_reply": "2026-04-05T04:05:38.198565Z"
+     "iopub.execute_input": "2026-04-15T16:44:49.681914Z",
+     "iopub.status.busy": "2026-04-15T16:44:49.681720Z",
+     "iopub.status.idle": "2026-04-15T16:44:49.725855Z",
+     "shell.execute_reply": "2026-04-15T16:44:49.725237Z"
     }
    },
    "outputs": [
@@ -5680,10 +5671,10 @@
    "execution_count": 61,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:38.201477Z",
-     "iopub.status.busy": "2026-04-05T04:05:38.201247Z",
-     "iopub.status.idle": "2026-04-05T04:05:39.361505Z",
-     "shell.execute_reply": "2026-04-05T04:05:39.360785Z"
+     "iopub.execute_input": "2026-04-15T16:44:49.727813Z",
+     "iopub.status.busy": "2026-04-15T16:44:49.727616Z",
+     "iopub.status.idle": "2026-04-15T16:44:50.797500Z",
+     "shell.execute_reply": "2026-04-15T16:44:50.796909Z"
     }
    },
    "outputs": [
@@ -5699,7 +5690,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
      ]
     }
@@ -5714,10 +5705,10 @@
    "execution_count": 62,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:39.363585Z",
-     "iopub.status.busy": "2026-04-05T04:05:39.363365Z",
-     "iopub.status.idle": "2026-04-05T04:05:39.403150Z",
-     "shell.execute_reply": "2026-04-05T04:05:39.402424Z"
+     "iopub.execute_input": "2026-04-15T16:44:50.799439Z",
+     "iopub.status.busy": "2026-04-15T16:44:50.799240Z",
+     "iopub.status.idle": "2026-04-15T16:44:50.839389Z",
+     "shell.execute_reply": "2026-04-15T16:44:50.838778Z"
     }
    },
    "outputs": [
@@ -5788,10 +5779,10 @@
    "execution_count": 63,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:39.405401Z",
-     "iopub.status.busy": "2026-04-05T04:05:39.405167Z",
-     "iopub.status.idle": "2026-04-05T04:05:43.698954Z",
-     "shell.execute_reply": "2026-04-05T04:05:43.698136Z"
+     "iopub.execute_input": "2026-04-15T16:44:50.841466Z",
+     "iopub.status.busy": "2026-04-15T16:44:50.841275Z",
+     "iopub.status.idle": "2026-04-15T16:44:54.409129Z",
+     "shell.execute_reply": "2026-04-15T16:44:54.408454Z"
     }
    },
    "outputs": [
@@ -5807,7 +5798,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.061, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.061, 'milligram / liter')>\n",
       " <Quantity(0.03, 'milligram / liter')>\n",
       " <Quantity(0.13, 'milligram / liter')> ...\n",
       " <Quantity(0.16, 'milligram / liter')>\n",
@@ -5848,10 +5839,10 @@
    "execution_count": 64,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:43.701190Z",
-     "iopub.status.busy": "2026-04-05T04:05:43.700971Z",
-     "iopub.status.idle": "2026-04-05T04:05:43.729715Z",
-     "shell.execute_reply": "2026-04-05T04:05:43.728975Z"
+     "iopub.execute_input": "2026-04-15T16:44:54.411294Z",
+     "iopub.status.busy": "2026-04-15T16:44:54.411081Z",
+     "iopub.status.idle": "2026-04-15T16:44:54.437673Z",
+     "shell.execute_reply": "2026-04-15T16:44:54.437089Z"
     }
    },
    "outputs": [
@@ -5998,10 +5989,10 @@
    "execution_count": 65,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:43.731722Z",
-     "iopub.status.busy": "2026-04-05T04:05:43.731521Z",
-     "iopub.status.idle": "2026-04-05T04:05:43.758853Z",
-     "shell.execute_reply": "2026-04-05T04:05:43.758116Z"
+     "iopub.execute_input": "2026-04-15T16:44:54.439577Z",
+     "iopub.status.busy": "2026-04-15T16:44:54.439401Z",
+     "iopub.status.idle": "2026-04-15T16:44:54.465076Z",
+     "shell.execute_reply": "2026-04-15T16:44:54.464504Z"
     }
    },
    "outputs": [
@@ -6147,10 +6138,10 @@
    "execution_count": 66,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:43.760820Z",
-     "iopub.status.busy": "2026-04-05T04:05:43.760616Z",
-     "iopub.status.idle": "2026-04-05T04:05:43.790796Z",
-     "shell.execute_reply": "2026-04-05T04:05:43.790050Z"
+     "iopub.execute_input": "2026-04-15T16:44:54.466986Z",
+     "iopub.status.busy": "2026-04-15T16:44:54.466812Z",
+     "iopub.status.idle": "2026-04-15T16:44:54.494944Z",
+     "shell.execute_reply": "2026-04-15T16:44:54.494342Z"
     }
    },
    "outputs": [
@@ -6594,10 +6585,10 @@
    "execution_count": 67,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:43.792794Z",
-     "iopub.status.busy": "2026-04-05T04:05:43.792590Z",
-     "iopub.status.idle": "2026-04-05T04:05:43.819292Z",
-     "shell.execute_reply": "2026-04-05T04:05:43.818414Z"
+     "iopub.execute_input": "2026-04-15T16:44:54.496810Z",
+     "iopub.status.busy": "2026-04-15T16:44:54.496626Z",
+     "iopub.status.idle": "2026-04-15T16:44:54.521099Z",
+     "shell.execute_reply": "2026-04-15T16:44:54.520493Z"
     }
    },
    "outputs": [
@@ -6764,10 +6755,10 @@
    "execution_count": 68,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:43.821620Z",
-     "iopub.status.busy": "2026-04-05T04:05:43.821424Z",
-     "iopub.status.idle": "2026-04-05T04:05:50.633891Z",
-     "shell.execute_reply": "2026-04-05T04:05:50.633124Z"
+     "iopub.execute_input": "2026-04-15T16:44:54.523176Z",
+     "iopub.status.busy": "2026-04-15T16:44:54.522954Z",
+     "iopub.status.idle": "2026-04-15T16:45:00.382827Z",
+     "shell.execute_reply": "2026-04-15T16:45:00.382190Z"
     }
    },
    "outputs": [
@@ -6783,9 +6774,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
     },
@@ -6801,7 +6798,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
      ]
     },
@@ -6845,10 +6842,10 @@
    "execution_count": 69,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:50.635877Z",
-     "iopub.status.busy": "2026-04-05T04:05:50.635677Z",
-     "iopub.status.idle": "2026-04-05T04:05:50.681934Z",
-     "shell.execute_reply": "2026-04-05T04:05:50.681136Z"
+     "iopub.execute_input": "2026-04-15T16:45:00.384705Z",
+     "iopub.status.busy": "2026-04-15T16:45:00.384511Z",
+     "iopub.status.idle": "2026-04-15T16:45:00.430346Z",
+     "shell.execute_reply": "2026-04-15T16:45:00.429688Z"
     }
    },
    "outputs": [
@@ -7014,10 +7011,10 @@
    "execution_count": 70,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:50.684016Z",
-     "iopub.status.busy": "2026-04-05T04:05:50.683802Z",
-     "iopub.status.idle": "2026-04-05T04:05:53.040084Z",
-     "shell.execute_reply": "2026-04-05T04:05:53.039356Z"
+     "iopub.execute_input": "2026-04-15T16:45:00.432574Z",
+     "iopub.status.busy": "2026-04-15T16:45:00.432366Z",
+     "iopub.status.idle": "2026-04-15T16:45:02.628917Z",
+     "shell.execute_reply": "2026-04-15T16:45:02.628311Z"
     }
    },
    "outputs": [
@@ -7033,19 +7030,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(12.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(12.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(6.0, 'Colony_Forming_Units / milliliter')> nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
      ]
@@ -7090,10 +7081,10 @@
    "execution_count": 71,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:53.042048Z",
-     "iopub.status.busy": "2026-04-05T04:05:53.041859Z",
-     "iopub.status.idle": "2026-04-05T04:05:53.086160Z",
-     "shell.execute_reply": "2026-04-05T04:05:53.085504Z"
+     "iopub.execute_input": "2026-04-15T16:45:02.630834Z",
+     "iopub.status.busy": "2026-04-15T16:45:02.630650Z",
+     "iopub.status.idle": "2026-04-15T16:45:02.674394Z",
+     "shell.execute_reply": "2026-04-15T16:45:02.673792Z"
     }
    },
    "outputs": [
@@ -7293,10 +7284,10 @@
    "execution_count": 72,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:53.088388Z",
-     "iopub.status.busy": "2026-04-05T04:05:53.088163Z",
-     "iopub.status.idle": "2026-04-05T04:05:53.090826Z",
-     "shell.execute_reply": "2026-04-05T04:05:53.090284Z"
+     "iopub.execute_input": "2026-04-15T16:45:02.676638Z",
+     "iopub.status.busy": "2026-04-15T16:45:02.676449Z",
+     "iopub.status.idle": "2026-04-15T16:45:02.679213Z",
+     "shell.execute_reply": "2026-04-15T16:45:02.678607Z"
     }
    },
    "outputs": [],
@@ -7309,10 +7300,10 @@
    "execution_count": 73,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:53.092626Z",
-     "iopub.status.busy": "2026-04-05T04:05:53.092449Z",
-     "iopub.status.idle": "2026-04-05T04:05:53.134003Z",
-     "shell.execute_reply": "2026-04-05T04:05:53.133378Z"
+     "iopub.execute_input": "2026-04-15T16:45:02.680899Z",
+     "iopub.status.busy": "2026-04-15T16:45:02.680728Z",
+     "iopub.status.idle": "2026-04-15T16:45:02.724092Z",
+     "shell.execute_reply": "2026-04-15T16:45:02.723515Z"
     }
    },
    "outputs": [
@@ -7339,10 +7330,10 @@
    "execution_count": 74,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:53.135923Z",
-     "iopub.status.busy": "2026-04-05T04:05:53.135712Z",
-     "iopub.status.idle": "2026-04-05T04:05:53.142959Z",
-     "shell.execute_reply": "2026-04-05T04:05:53.142426Z"
+     "iopub.execute_input": "2026-04-15T16:45:02.725961Z",
+     "iopub.status.busy": "2026-04-15T16:45:02.725780Z",
+     "iopub.status.idle": "2026-04-15T16:45:02.733051Z",
+     "shell.execute_reply": "2026-04-15T16:45:02.732460Z"
     }
    },
    "outputs": [
@@ -7374,10 +7365,10 @@
    "execution_count": 75,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:53.144853Z",
-     "iopub.status.busy": "2026-04-05T04:05:53.144673Z",
-     "iopub.status.idle": "2026-04-05T04:05:53.147273Z",
-     "shell.execute_reply": "2026-04-05T04:05:53.146748Z"
+     "iopub.execute_input": "2026-04-15T16:45:02.734990Z",
+     "iopub.status.busy": "2026-04-15T16:45:02.734805Z",
+     "iopub.status.idle": "2026-04-15T16:45:02.737504Z",
+     "shell.execute_reply": "2026-04-15T16:45:02.736923Z"
     }
    },
    "outputs": [],
@@ -7391,10 +7382,10 @@
    "execution_count": 76,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:05:53.149026Z",
-     "iopub.status.busy": "2026-04-05T04:05:53.148827Z",
-     "iopub.status.idle": "2026-04-05T04:06:07.202493Z",
-     "shell.execute_reply": "2026-04-05T04:06:07.201714Z"
+     "iopub.execute_input": "2026-04-15T16:45:02.739360Z",
+     "iopub.status.busy": "2026-04-15T16:45:02.739179Z",
+     "iopub.status.idle": "2026-04-15T16:45:16.268932Z",
+     "shell.execute_reply": "2026-04-15T16:45:16.268289Z"
     }
    },
    "outputs": [
@@ -7505,10 +7496,10 @@
    "execution_count": 77,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:07.204666Z",
-     "iopub.status.busy": "2026-04-05T04:06:07.204460Z",
-     "iopub.status.idle": "2026-04-05T04:06:07.207260Z",
-     "shell.execute_reply": "2026-04-05T04:06:07.206692Z"
+     "iopub.execute_input": "2026-04-15T16:45:16.271024Z",
+     "iopub.status.busy": "2026-04-15T16:45:16.270818Z",
+     "iopub.status.idle": "2026-04-15T16:45:16.273463Z",
+     "shell.execute_reply": "2026-04-15T16:45:16.272976Z"
     }
    },
    "outputs": [],
@@ -7521,10 +7512,10 @@
    "execution_count": 78,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:07.209023Z",
-     "iopub.status.busy": "2026-04-05T04:06:07.208827Z",
-     "iopub.status.idle": "2026-04-05T04:06:47.656960Z",
-     "shell.execute_reply": "2026-04-05T04:06:47.656270Z"
+     "iopub.execute_input": "2026-04-15T16:45:16.275216Z",
+     "iopub.status.busy": "2026-04-15T16:45:16.274998Z",
+     "iopub.status.idle": "2026-04-15T16:46:04.426070Z",
+     "shell.execute_reply": "2026-04-15T16:46:04.425498Z"
     }
    },
    "outputs": [],
@@ -7541,10 +7532,10 @@
    "execution_count": 79,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:47.659105Z",
-     "iopub.status.busy": "2026-04-05T04:06:47.658918Z",
-     "iopub.status.idle": "2026-04-05T04:06:52.514485Z",
-     "shell.execute_reply": "2026-04-05T04:06:52.513840Z"
+     "iopub.execute_input": "2026-04-15T16:46:04.428512Z",
+     "iopub.status.busy": "2026-04-15T16:46:04.428282Z",
+     "iopub.status.idle": "2026-04-15T16:46:08.719463Z",
+     "shell.execute_reply": "2026-04-15T16:46:08.718779Z"
     }
    },
    "outputs": [
@@ -7648,7 +7639,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>412358</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppt</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7659,7 +7650,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>412574</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppt</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7670,7 +7661,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>427603</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7681,7 +7672,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>432957</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppt</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7692,7 +7683,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>457784</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7714,11 +7705,11 @@
        "4345                 0.00                          ppth     NaN   \n",
        "4558                    0                           ppt     NaN   \n",
        "...                   ...                           ...     ...   \n",
-       "412358                0.0                           ppt     NaN   \n",
-       "412574                0.0                           ppt     NaN   \n",
-       "427603                0.0                          ppth     NaN   \n",
-       "432957                0.0                           ppt     NaN   \n",
-       "457784                0.0                          ppth     NaN   \n",
+       "412358                  0                           ppt     NaN   \n",
+       "412574                  0                           ppt     NaN   \n",
+       "427603                  0                          ppth     NaN   \n",
+       "432957                  0                           ppt     NaN   \n",
+       "457784                  0                          ppth     NaN   \n",
        "\n",
        "                            Salinity ResultDetectionConditionText  \\\n",
        "1316    0.0 Practical_Salinity_Units                          NaN   \n",
@@ -7797,10 +7788,10 @@
    "execution_count": 80,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:52.516709Z",
-     "iopub.status.busy": "2026-04-05T04:06:52.516517Z",
-     "iopub.status.idle": "2026-04-05T04:06:52.530680Z",
-     "shell.execute_reply": "2026-04-05T04:06:52.529930Z"
+     "iopub.execute_input": "2026-04-15T16:46:08.721419Z",
+     "iopub.status.busy": "2026-04-15T16:46:08.721225Z",
+     "iopub.status.idle": "2026-04-15T16:46:08.734246Z",
+     "shell.execute_reply": "2026-04-15T16:46:08.733767Z"
     }
    },
    "outputs": [
@@ -7844,10 +7835,10 @@
    "execution_count": 81,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:52.532886Z",
-     "iopub.status.busy": "2026-04-05T04:06:52.532681Z",
-     "iopub.status.idle": "2026-04-05T04:06:52.887525Z",
-     "shell.execute_reply": "2026-04-05T04:06:52.886708Z"
+     "iopub.execute_input": "2026-04-15T16:46:08.736168Z",
+     "iopub.status.busy": "2026-04-15T16:46:08.735952Z",
+     "iopub.status.idle": "2026-04-15T16:46:09.046281Z",
+     "shell.execute_reply": "2026-04-15T16:46:09.045591Z"
     }
    },
    "outputs": [
@@ -8020,10 +8011,10 @@
    "execution_count": 82,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:52.889716Z",
-     "iopub.status.busy": "2026-04-05T04:06:52.889485Z",
-     "iopub.status.idle": "2026-04-05T04:06:52.922567Z",
-     "shell.execute_reply": "2026-04-05T04:06:52.921820Z"
+     "iopub.execute_input": "2026-04-15T16:46:09.048237Z",
+     "iopub.status.busy": "2026-04-15T16:46:09.048014Z",
+     "iopub.status.idle": "2026-04-15T16:46:09.079488Z",
+     "shell.execute_reply": "2026-04-15T16:46:09.078866Z"
     }
    },
    "outputs": [
@@ -8195,10 +8186,10 @@
    "execution_count": 83,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:52.924748Z",
-     "iopub.status.busy": "2026-04-05T04:06:52.924526Z",
-     "iopub.status.idle": "2026-04-05T04:06:53.605456Z",
-     "shell.execute_reply": "2026-04-05T04:06:53.604722Z"
+     "iopub.execute_input": "2026-04-15T16:46:09.081523Z",
+     "iopub.status.busy": "2026-04-15T16:46:09.081308Z",
+     "iopub.status.idle": "2026-04-15T16:46:09.633977Z",
+     "shell.execute_reply": "2026-04-15T16:46:09.633361Z"
     }
    },
    "outputs": [
@@ -8250,10 +8241,10 @@
    "execution_count": 84,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:53.607598Z",
-     "iopub.status.busy": "2026-04-05T04:06:53.607412Z",
-     "iopub.status.idle": "2026-04-05T04:06:53.619498Z",
-     "shell.execute_reply": "2026-04-05T04:06:53.618834Z"
+     "iopub.execute_input": "2026-04-15T16:46:09.635984Z",
+     "iopub.status.busy": "2026-04-15T16:46:09.635802Z",
+     "iopub.status.idle": "2026-04-15T16:46:09.647688Z",
+     "shell.execute_reply": "2026-04-15T16:46:09.647171Z"
     }
    },
    "outputs": [
@@ -8388,10 +8379,10 @@
    "execution_count": 85,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:53.621437Z",
-     "iopub.status.busy": "2026-04-05T04:06:53.621183Z",
-     "iopub.status.idle": "2026-04-05T04:06:54.545870Z",
-     "shell.execute_reply": "2026-04-05T04:06:54.545219Z"
+     "iopub.execute_input": "2026-04-15T16:46:09.649478Z",
+     "iopub.status.busy": "2026-04-15T16:46:09.649302Z",
+     "iopub.status.idle": "2026-04-15T16:46:10.533476Z",
+     "shell.execute_reply": "2026-04-15T16:46:10.532839Z"
     }
    },
    "outputs": [
@@ -8535,10 +8526,10 @@
    "execution_count": 86,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:54.548032Z",
-     "iopub.status.busy": "2026-04-05T04:06:54.547826Z",
-     "iopub.status.idle": "2026-04-05T04:06:54.938183Z",
-     "shell.execute_reply": "2026-04-05T04:06:54.937513Z"
+     "iopub.execute_input": "2026-04-15T16:46:10.535531Z",
+     "iopub.status.busy": "2026-04-15T16:46:10.535352Z",
+     "iopub.status.idle": "2026-04-15T16:46:10.890913Z",
+     "shell.execute_reply": "2026-04-15T16:46:10.890310Z"
     }
    },
    "outputs": [
@@ -8583,10 +8574,10 @@
    "execution_count": 87,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:54.940210Z",
-     "iopub.status.busy": "2026-04-05T04:06:54.940004Z",
-     "iopub.status.idle": "2026-04-05T04:06:59.673746Z",
-     "shell.execute_reply": "2026-04-05T04:06:59.672987Z"
+     "iopub.execute_input": "2026-04-15T16:46:10.892853Z",
+     "iopub.status.busy": "2026-04-15T16:46:10.892672Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.349817Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.349136Z"
     }
    },
    "outputs": [
@@ -8622,16 +8613,16 @@
        "      <th>DataLoggerLine</th>\n",
        "      <th>ResultDetectionConditionText</th>\n",
        "      <th>...</th>\n",
-       "      <th>QA_DO</th>\n",
-       "      <th>QA_Carbon</th>\n",
-       "      <th>QA_Conductivity</th>\n",
+       "      <th>QA_pH</th>\n",
+       "      <th>QA_Nitrogen</th>\n",
        "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Secchi</th>\n",
+       "      <th>QA_E_coli</th>\n",
+       "      <th>QA_Chlorophyll</th>\n",
+       "      <th>QA_Temperature</th>\n",
+       "      <th>QA_Fecal_Coliform</th>\n",
        "      <th>QA_TP_Phosphorus</th>\n",
        "      <th>QA_TDP_Phosphorus</th>\n",
        "      <th>QA_Other_Phosphorus</th>\n",
-       "      <th>QA_Chlorophyll</th>\n",
-       "      <th>QA_Nitrogen</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -8970,44 +8961,44 @@
        "463844    NWIS-104000936             NaN                          NaN  ...   \n",
        "463845     NWIS-53918826             NaN                          NaN  ...   \n",
        "\n",
-       "       QA_DO QA_Carbon QA_Conductivity QA_Turbidity QA_Secchi  \\\n",
-       "155202   NaN       NaN             NaN          NaN       NaN   \n",
-       "158906   NaN       NaN             NaN          NaN       NaN   \n",
-       "151458   NaN       NaN             NaN          NaN       NaN   \n",
-       "157518   NaN       NaN             NaN          NaN       NaN   \n",
-       "150769   NaN       NaN             NaN          NaN       NaN   \n",
-       "...      ...       ...             ...          ...       ...   \n",
-       "463841   NaN       NaN             NaN          NaN       NaN   \n",
-       "463842   NaN       NaN             NaN          NaN       NaN   \n",
-       "463843   NaN       NaN             NaN          NaN       NaN   \n",
-       "463844   NaN       NaN             NaN          NaN       NaN   \n",
-       "463845   NaN       NaN             NaN          NaN       NaN   \n",
+       "       QA_pH QA_Nitrogen QA_Turbidity QA_E_coli QA_Chlorophyll QA_Temperature  \\\n",
+       "155202   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "158906   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "151458   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "157518   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "150769   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "...      ...         ...          ...       ...            ...            ...   \n",
+       "463841   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "463842   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "463843   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "463844   NaN         NaN          NaN       NaN            NaN            NaN   \n",
+       "463845   NaN         NaN          NaN       NaN            NaN            NaN   \n",
        "\n",
-       "       QA_TP_Phosphorus QA_TDP_Phosphorus QA_Other_Phosphorus QA_Chlorophyll  \\\n",
-       "155202              NaN               NaN                 NaN            NaN   \n",
-       "158906              NaN               NaN                 NaN            NaN   \n",
-       "151458              NaN               NaN                 NaN            NaN   \n",
-       "157518              NaN               NaN                 NaN            NaN   \n",
-       "150769              NaN               NaN                 NaN            NaN   \n",
-       "...                 ...               ...                 ...            ...   \n",
-       "463841              NaN               NaN                 NaN            NaN   \n",
-       "463842              NaN               NaN                 NaN            NaN   \n",
-       "463843              NaN               NaN                 NaN            NaN   \n",
-       "463844              NaN               NaN                 NaN            NaN   \n",
-       "463845              NaN               NaN                 NaN            NaN   \n",
+       "       QA_Fecal_Coliform QA_TP_Phosphorus QA_TDP_Phosphorus  \\\n",
+       "155202               NaN              NaN               NaN   \n",
+       "158906               NaN              NaN               NaN   \n",
+       "151458               NaN              NaN               NaN   \n",
+       "157518               NaN              NaN               NaN   \n",
+       "150769               NaN              NaN               NaN   \n",
+       "...                  ...              ...               ...   \n",
+       "463841               NaN              NaN               NaN   \n",
+       "463842               NaN              NaN               NaN   \n",
+       "463843               NaN              NaN               NaN   \n",
+       "463844               NaN              NaN               NaN   \n",
+       "463845               NaN              NaN               NaN   \n",
        "\n",
-       "       QA_Nitrogen  \n",
-       "155202         NaN  \n",
-       "158906         NaN  \n",
-       "151458         NaN  \n",
-       "157518         NaN  \n",
-       "150769         NaN  \n",
-       "...            ...  \n",
-       "463841         NaN  \n",
-       "463842         NaN  \n",
-       "463843         NaN  \n",
-       "463844         NaN  \n",
-       "463845         NaN  \n",
+       "       QA_Other_Phosphorus  \n",
+       "155202                 NaN  \n",
+       "158906                 NaN  \n",
+       "151458                 NaN  \n",
+       "157518                 NaN  \n",
+       "150769                 NaN  \n",
+       "...                    ...  \n",
+       "463841                 NaN  \n",
+       "463842                 NaN  \n",
+       "463843                 NaN  \n",
+       "463844                 NaN  \n",
+       "463845                 NaN  \n",
        "\n",
        "[408985 rows x 117 columns]"
       ]
@@ -9028,10 +9019,10 @@
    "execution_count": 88,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:59.675861Z",
-     "iopub.status.busy": "2026-04-05T04:06:59.675657Z",
-     "iopub.status.idle": "2026-04-05T04:06:59.679296Z",
-     "shell.execute_reply": "2026-04-05T04:06:59.678754Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.351837Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.351641Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.355003Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.354434Z"
     }
    },
    "outputs": [
@@ -9053,10 +9044,10 @@
    "execution_count": 89,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:59.681039Z",
-     "iopub.status.busy": "2026-04-05T04:06:59.680846Z",
-     "iopub.status.idle": "2026-04-05T04:06:59.684242Z",
-     "shell.execute_reply": "2026-04-05T04:06:59.683702Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.357041Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.356817Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.360051Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.359523Z"
     }
    },
    "outputs": [
@@ -9078,10 +9069,10 @@
    "execution_count": 90,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:59.686008Z",
-     "iopub.status.busy": "2026-04-05T04:06:59.685835Z",
-     "iopub.status.idle": "2026-04-05T04:06:59.709727Z",
-     "shell.execute_reply": "2026-04-05T04:06:59.709124Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.361859Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.361667Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.384755Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.384181Z"
     }
    },
    "outputs": [
@@ -9146,10 +9137,10 @@
    "execution_count": 91,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:06:59.711722Z",
-     "iopub.status.busy": "2026-04-05T04:06:59.711537Z",
-     "iopub.status.idle": "2026-04-05T04:07:00.289784Z",
-     "shell.execute_reply": "2026-04-05T04:07:00.289108Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.386755Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.386560Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.931063Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.930499Z"
     }
    },
    "outputs": [],
@@ -9163,10 +9154,10 @@
    "execution_count": 92,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:00.292025Z",
-     "iopub.status.busy": "2026-04-05T04:07:00.291843Z",
-     "iopub.status.idle": "2026-04-05T04:07:00.296046Z",
-     "shell.execute_reply": "2026-04-05T04:07:00.295492Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.933336Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.933145Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.937365Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.936841Z"
     }
    },
    "outputs": [
@@ -9182,11 +9173,11 @@
        "       'E_coli', 'DetectionQuantitationLimitTypeName',\n",
        "       'DetectionQuantitationLimitMeasure/MeasureValue',\n",
        "       'DetectionQuantitationLimitMeasure/MeasureUnitCode',\n",
-       "       'Activity_datetime', 'Depth', 'QA_Fecal_Coliform', 'QA_pH', 'QA_E_coli',\n",
-       "       'QA_Temperature', 'QA_Salinity', 'QA_DO', 'QA_Carbon',\n",
-       "       'QA_Conductivity', 'QA_Turbidity', 'QA_Secchi', 'QA_TP_Phosphorus',\n",
-       "       'QA_TDP_Phosphorus', 'QA_Other_Phosphorus', 'QA_Chlorophyll',\n",
-       "       'QA_Nitrogen'],\n",
+       "       'Activity_datetime', 'Depth', 'QA_Secchi', 'QA_Salinity',\n",
+       "       'QA_Conductivity', 'QA_DO', 'QA_Carbon', 'QA_pH', 'QA_Nitrogen',\n",
+       "       'QA_Turbidity', 'QA_E_coli', 'QA_Chlorophyll', 'QA_Temperature',\n",
+       "       'QA_Fecal_Coliform', 'QA_TP_Phosphorus', 'QA_TDP_Phosphorus',\n",
+       "       'QA_Other_Phosphorus'],\n",
        "      dtype='object')"
       ]
      },
@@ -9205,10 +9196,10 @@
    "execution_count": 93,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:00.297852Z",
-     "iopub.status.busy": "2026-04-05T04:07:00.297671Z",
-     "iopub.status.idle": "2026-04-05T04:07:00.311648Z",
-     "shell.execute_reply": "2026-04-05T04:07:00.311084Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.939017Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.938849Z",
+     "iopub.status.idle": "2026-04-15T16:46:15.951187Z",
+     "shell.execute_reply": "2026-04-15T16:46:15.950658Z"
     }
    },
    "outputs": [
@@ -9244,16 +9235,16 @@
        "      <th>pH</th>\n",
        "      <th>Salinity</th>\n",
        "      <th>...</th>\n",
-       "      <th>QA_DO</th>\n",
-       "      <th>QA_Carbon</th>\n",
-       "      <th>QA_Conductivity</th>\n",
+       "      <th>QA_pH</th>\n",
+       "      <th>QA_Nitrogen</th>\n",
        "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Secchi</th>\n",
+       "      <th>QA_E_coli</th>\n",
+       "      <th>QA_Chlorophyll</th>\n",
+       "      <th>QA_Temperature</th>\n",
+       "      <th>QA_Fecal_Coliform</th>\n",
        "      <th>QA_TP_Phosphorus</th>\n",
        "      <th>QA_TDP_Phosphorus</th>\n",
        "      <th>QA_Other_Phosphorus</th>\n",
-       "      <th>QA_Chlorophyll</th>\n",
-       "      <th>QA_Nitrogen</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -9404,26 +9395,33 @@
        "157518  21AWIC-51908_230229_173                  21AWIC-1122       STORET   \n",
        "150769  21AWIC-51908_230227_173                  21AWIC-1122       STORET   \n",
        "\n",
-       "       Secchi Temperature   DO   pH              Salinity  ... QA_DO  \\\n",
+       "       Secchi Temperature   DO   pH              Salinity  ... QA_pH  \\\n",
        "155202    NaN         NaN  NaN  NaN  36.356 dimensionless  ...   NaN   \n",
        "158906    NaN         NaN  NaN  NaN  36.345 dimensionless  ...   NaN   \n",
        "151458    NaN         NaN  NaN  NaN  36.338 dimensionless  ...   NaN   \n",
        "157518    NaN         NaN  NaN  NaN  36.336 dimensionless  ...   NaN   \n",
        "150769    NaN         NaN  NaN  NaN   36.33 dimensionless  ...   NaN   \n",
        "\n",
-       "       QA_Carbon QA_Conductivity QA_Turbidity QA_Secchi QA_TP_Phosphorus  \\\n",
-       "155202       NaN             NaN          NaN       NaN              NaN   \n",
-       "158906       NaN             NaN          NaN       NaN              NaN   \n",
-       "151458       NaN             NaN          NaN       NaN              NaN   \n",
-       "157518       NaN             NaN          NaN       NaN              NaN   \n",
-       "150769       NaN             NaN          NaN       NaN              NaN   \n",
+       "       QA_Nitrogen QA_Turbidity QA_E_coli QA_Chlorophyll QA_Temperature  \\\n",
+       "155202         NaN          NaN       NaN            NaN            NaN   \n",
+       "158906         NaN          NaN       NaN            NaN            NaN   \n",
+       "151458         NaN          NaN       NaN            NaN            NaN   \n",
+       "157518         NaN          NaN       NaN            NaN            NaN   \n",
+       "150769         NaN          NaN       NaN            NaN            NaN   \n",
        "\n",
-       "       QA_TDP_Phosphorus QA_Other_Phosphorus QA_Chlorophyll QA_Nitrogen  \n",
-       "155202               NaN                 NaN            NaN         NaN  \n",
-       "158906               NaN                 NaN            NaN         NaN  \n",
-       "151458               NaN                 NaN            NaN         NaN  \n",
-       "157518               NaN                 NaN            NaN         NaN  \n",
-       "150769               NaN                 NaN            NaN         NaN  \n",
+       "       QA_Fecal_Coliform QA_TP_Phosphorus QA_TDP_Phosphorus  \\\n",
+       "155202               NaN              NaN               NaN   \n",
+       "158906               NaN              NaN               NaN   \n",
+       "151458               NaN              NaN               NaN   \n",
+       "157518               NaN              NaN               NaN   \n",
+       "150769               NaN              NaN               NaN   \n",
+       "\n",
+       "       QA_Other_Phosphorus  \n",
+       "155202                 NaN  \n",
+       "158906                 NaN  \n",
+       "151458                 NaN  \n",
+       "157518                 NaN  \n",
+       "150769                 NaN  \n",
        "\n",
        "[5 rows x 44 columns]"
       ]
@@ -9443,10 +9441,10 @@
    "execution_count": 94,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:00.313418Z",
-     "iopub.status.busy": "2026-04-05T04:07:00.313221Z",
-     "iopub.status.idle": "2026-04-05T04:07:00.713679Z",
-     "shell.execute_reply": "2026-04-05T04:07:00.712917Z"
+     "iopub.execute_input": "2026-04-15T16:46:15.952890Z",
+     "iopub.status.busy": "2026-04-15T16:46:15.952703Z",
+     "iopub.status.idle": "2026-04-15T16:46:16.363001Z",
+     "shell.execute_reply": "2026-04-15T16:46:16.362447Z"
     }
    },
    "outputs": [
@@ -9454,11 +9452,11 @@
      "data": {
       "text/plain": [
        "['Sediment',\n",
-       " 'QA_Fecal_Coliform',\n",
-       " 'QA_E_coli',\n",
-       " 'QA_Carbon',\n",
-       " 'QA_Conductivity',\n",
        " 'QA_Secchi',\n",
+       " 'QA_Conductivity',\n",
+       " 'QA_Carbon',\n",
+       " 'QA_E_coli',\n",
+       " 'QA_Fecal_Coliform',\n",
        " 'QA_TP_Phosphorus',\n",
        " 'QA_TDP_Phosphorus',\n",
        " 'QA_Other_Phosphorus']"
@@ -9481,10 +9479,10 @@
    "execution_count": 95,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:00.715707Z",
-     "iopub.status.busy": "2026-04-05T04:07:00.715508Z",
-     "iopub.status.idle": "2026-04-05T04:07:01.096416Z",
-     "shell.execute_reply": "2026-04-05T04:07:01.095784Z"
+     "iopub.execute_input": "2026-04-15T16:46:16.364901Z",
+     "iopub.status.busy": "2026-04-15T16:46:16.364726Z",
+     "iopub.status.idle": "2026-04-15T16:46:16.736519Z",
+     "shell.execute_reply": "2026-04-15T16:46:16.735896Z"
     }
    },
    "outputs": [

--- a/demos/Harmonize_Pensacola_Simple.ipynb
+++ b/demos/Harmonize_Pensacola_Simple.ipynb
@@ -55,10 +55,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:05.906479Z",
-     "iopub.status.busy": "2026-04-05T04:07:05.906254Z",
-     "iopub.status.idle": "2026-04-05T04:07:05.912506Z",
-     "shell.execute_reply": "2026-04-05T04:07:05.911960Z"
+     "iopub.execute_input": "2026-04-15T16:46:21.442412Z",
+     "iopub.status.busy": "2026-04-15T16:46:21.442134Z",
+     "iopub.status.idle": "2026-04-15T16:46:21.448232Z",
+     "shell.execute_reply": "2026-04-15T16:46:21.447749Z"
     }
    },
    "outputs": [],
@@ -83,10 +83,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:05.914403Z",
-     "iopub.status.busy": "2026-04-05T04:07:05.914195Z",
-     "iopub.status.idle": "2026-04-05T04:07:06.534937Z",
-     "shell.execute_reply": "2026-04-05T04:07:06.534261Z"
+     "iopub.execute_input": "2026-04-15T16:46:21.450062Z",
+     "iopub.status.busy": "2026-04-15T16:46:21.449893Z",
+     "iopub.status.idle": "2026-04-15T16:46:22.035173Z",
+     "shell.execute_reply": "2026-04-15T16:46:22.034499Z"
     }
    },
    "outputs": [],
@@ -100,10 +100,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:06.537238Z",
-     "iopub.status.busy": "2026-04-05T04:07:06.536985Z",
-     "iopub.status.idle": "2026-04-05T04:07:06.539792Z",
-     "shell.execute_reply": "2026-04-05T04:07:06.539232Z"
+     "iopub.execute_input": "2026-04-15T16:46:22.037619Z",
+     "iopub.status.busy": "2026-04-15T16:46:22.037364Z",
+     "iopub.status.idle": "2026-04-15T16:46:22.040154Z",
+     "shell.execute_reply": "2026-04-15T16:46:22.039576Z"
     }
    },
    "outputs": [],
@@ -118,10 +118,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:06.541713Z",
-     "iopub.status.busy": "2026-04-05T04:07:06.541528Z",
-     "iopub.status.idle": "2026-04-05T04:07:07.290669Z",
-     "shell.execute_reply": "2026-04-05T04:07:07.289963Z"
+     "iopub.execute_input": "2026-04-15T16:46:22.042073Z",
+     "iopub.status.busy": "2026-04-15T16:46:22.041881Z",
+     "iopub.status.idle": "2026-04-15T16:46:22.612244Z",
+     "shell.execute_reply": "2026-04-15T16:46:22.611597Z"
     }
    },
    "outputs": [
@@ -156,10 +156,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:07.305253Z",
-     "iopub.status.busy": "2026-04-05T04:07:07.304958Z",
-     "iopub.status.idle": "2026-04-05T04:07:07.385634Z",
-     "shell.execute_reply": "2026-04-05T04:07:07.385004Z"
+     "iopub.execute_input": "2026-04-15T16:46:22.630400Z",
+     "iopub.status.busy": "2026-04-15T16:46:22.630069Z",
+     "iopub.status.idle": "2026-04-15T16:46:22.688951Z",
+     "shell.execute_reply": "2026-04-15T16:46:22.688429Z"
     }
    },
    "outputs": [],
@@ -177,21 +177,13 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:07:07.387853Z",
-     "iopub.status.busy": "2026-04-05T04:07:07.387647Z",
-     "iopub.status.idle": "2026-04-05T04:13:48.296509Z",
-     "shell.execute_reply": "2026-04-05T04:13:48.295779Z"
+     "iopub.execute_input": "2026-04-15T16:46:22.691019Z",
+     "iopub.status.busy": "2026-04-15T16:46:22.690844Z",
+     "iopub.status.idle": "2026-04-15T16:46:23.525982Z",
+     "shell.execute_reply": "2026-04-15T16:46:23.525288Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:153: DtypeWarning: Columns (9,13,17,23,31,61,62,64,65,71) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    },
     {
      "data": {
       "text/html": [
@@ -680,10 +672,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:13:48.298810Z",
-     "iopub.status.busy": "2026-04-05T04:13:48.298623Z",
-     "iopub.status.idle": "2026-04-05T04:13:48.301745Z",
-     "shell.execute_reply": "2026-04-05T04:13:48.301041Z"
+     "iopub.execute_input": "2026-04-15T16:46:23.528059Z",
+     "iopub.status.busy": "2026-04-15T16:46:23.527854Z",
+     "iopub.status.idle": "2026-04-15T16:46:23.530478Z",
+     "shell.execute_reply": "2026-04-15T16:46:23.529994Z"
     }
    },
    "outputs": [],
@@ -697,10 +689,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:13:48.303674Z",
-     "iopub.status.busy": "2026-04-05T04:13:48.303490Z",
-     "iopub.status.idle": "2026-04-05T04:13:50.860385Z",
-     "shell.execute_reply": "2026-04-05T04:13:50.859664Z"
+     "iopub.execute_input": "2026-04-15T16:46:23.532200Z",
+     "iopub.status.busy": "2026-04-15T16:46:23.532001Z",
+     "iopub.status.idle": "2026-04-15T16:46:25.822644Z",
+     "shell.execute_reply": "2026-04-15T16:46:25.822002Z"
     },
     "hidden": true
    },
@@ -710,13 +702,7 @@
      "output_type": "stream",
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:158: FutureWarning: unique with argument that is not not a Series, Index, ExtensionArray, or np.ndarray is deprecated and will raise in a future version.\n",
-      "  for bad_meas in pandas.unique(bad_measures):\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  for bad_meas in pandas.unique(bad_measures):\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/clean.py:360: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value 'ResultMeasureValue: \"Not Reported\" result cannot be used' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[mask & (df_out[\"QA_flag\"].isna()), \"QA_flag\"] = flag\n"
      ]
@@ -725,7 +711,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(2.0, 'meter')> <Quantity(0.94, 'meter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(2.0, 'meter')> <Quantity(0.94, 'meter')>\n",
       " <Quantity(0.6, 'meter')> ... <Quantity(1.67, 'meter')>\n",
       " <Quantity(0.3048, 'meter')> <Quantity(0.11, 'meter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n",
@@ -737,7 +723,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(26.0555556, 'degree_Celsius')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(26.0555556, 'degree_Celsius')>\n",
       " <Quantity(12.35, 'degree_Celsius')> <Quantity(23.0, 'degree_Celsius')>\n",
       " ... <Quantity(25.0, 'degree_Celsius')> <Quantity(24.0, 'degree_Celsius')>\n",
       " <Quantity(20.5, 'degree_Celsius')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
@@ -1208,10 +1194,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:13:50.862292Z",
-     "iopub.status.busy": "2026-04-05T04:13:50.862092Z",
-     "iopub.status.idle": "2026-04-05T04:13:51.726849Z",
-     "shell.execute_reply": "2026-04-05T04:13:51.726194Z"
+     "iopub.execute_input": "2026-04-15T16:46:25.825052Z",
+     "iopub.status.busy": "2026-04-15T16:46:25.824851Z",
+     "iopub.status.idle": "2026-04-15T16:46:26.658923Z",
+     "shell.execute_reply": "2026-04-15T16:46:26.658285Z"
     }
    },
    "outputs": [
@@ -1698,10 +1684,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:13:51.729112Z",
-     "iopub.status.busy": "2026-04-05T04:13:51.728898Z",
-     "iopub.status.idle": "2026-04-05T04:14:02.904931Z",
-     "shell.execute_reply": "2026-04-05T04:14:02.904184Z"
+     "iopub.execute_input": "2026-04-15T16:46:26.661042Z",
+     "iopub.status.busy": "2026-04-15T16:46:26.660850Z",
+     "iopub.status.idle": "2026-04-15T16:46:36.327130Z",
+     "shell.execute_reply": "2026-04-15T16:46:36.326511Z"
     },
     "hidden": true
    },
@@ -1710,7 +1696,7 @@
      "data": {
       "text/plain": [
        "Index(['OrganizationFormalName', 'ProviderName', 'Secchi', 'Temperature',\n",
-       "       'Depth', 'QA_Temperature', 'QA_Secchi'],\n",
+       "       'Depth', 'QA_Secchi', 'QA_Temperature'],\n",
        "      dtype='object')"
       ]
      },
@@ -1758,10 +1744,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:02.907006Z",
-     "iopub.status.busy": "2026-04-05T04:14:02.906804Z",
-     "iopub.status.idle": "2026-04-05T04:14:09.570353Z",
-     "shell.execute_reply": "2026-04-05T04:14:09.569722Z"
+     "iopub.execute_input": "2026-04-15T16:46:36.329216Z",
+     "iopub.status.busy": "2026-04-15T16:46:36.328990Z",
+     "iopub.status.idle": "2026-04-15T16:46:36.578759Z",
+     "shell.execute_reply": "2026-04-15T16:46:36.578013Z"
     },
     "hidden": true
    },
@@ -1796,10 +1782,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:09.572766Z",
-     "iopub.status.busy": "2026-04-05T04:14:09.572551Z",
-     "iopub.status.idle": "2026-04-05T04:14:09.883664Z",
-     "shell.execute_reply": "2026-04-05T04:14:09.882895Z"
+     "iopub.execute_input": "2026-04-15T16:46:36.580739Z",
+     "iopub.status.busy": "2026-04-15T16:46:36.580550Z",
+     "iopub.status.idle": "2026-04-15T16:46:36.883529Z",
+     "shell.execute_reply": "2026-04-15T16:46:36.882903Z"
     },
     "hidden": true
    },

--- a/demos/Harmonize_Tampa_Detailed.ipynb
+++ b/demos/Harmonize_Tampa_Detailed.ipynb
@@ -54,10 +54,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:13.995856Z",
-     "iopub.status.busy": "2026-04-05T04:14:13.995653Z",
-     "iopub.status.idle": "2026-04-05T04:14:14.002007Z",
-     "shell.execute_reply": "2026-04-05T04:14:14.001352Z"
+     "iopub.execute_input": "2026-04-15T16:46:40.892832Z",
+     "iopub.status.busy": "2026-04-15T16:46:40.892637Z",
+     "iopub.status.idle": "2026-04-15T16:46:40.898702Z",
+     "shell.execute_reply": "2026-04-15T16:46:40.898139Z"
     }
    },
    "outputs": [],
@@ -75,10 +75,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:14.003994Z",
-     "iopub.status.busy": "2026-04-05T04:14:14.003818Z",
-     "iopub.status.idle": "2026-04-05T04:14:14.617587Z",
-     "shell.execute_reply": "2026-04-05T04:14:14.616958Z"
+     "iopub.execute_input": "2026-04-15T16:46:40.900639Z",
+     "iopub.status.busy": "2026-04-15T16:46:40.900449Z",
+     "iopub.status.idle": "2026-04-15T16:46:41.476895Z",
+     "shell.execute_reply": "2026-04-15T16:46:41.476227Z"
     }
    },
    "outputs": [],
@@ -103,10 +103,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:14.619940Z",
-     "iopub.status.busy": "2026-04-05T04:14:14.619686Z",
-     "iopub.status.idle": "2026-04-05T04:14:17.764264Z",
-     "shell.execute_reply": "2026-04-05T04:14:17.763585Z"
+     "iopub.execute_input": "2026-04-15T16:46:41.479439Z",
+     "iopub.status.busy": "2026-04-15T16:46:41.479184Z",
+     "iopub.status.idle": "2026-04-15T16:46:43.246074Z",
+     "shell.execute_reply": "2026-04-15T16:46:43.245511Z"
     }
    },
    "outputs": [
@@ -144,10 +144,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:17.781956Z",
-     "iopub.status.busy": "2026-04-05T04:14:17.781610Z",
-     "iopub.status.idle": "2026-04-05T04:14:17.786137Z",
-     "shell.execute_reply": "2026-04-05T04:14:17.785566Z"
+     "iopub.execute_input": "2026-04-15T16:46:43.255858Z",
+     "iopub.status.busy": "2026-04-15T16:46:43.255543Z",
+     "iopub.status.idle": "2026-04-15T16:46:43.259568Z",
+     "shell.execute_reply": "2026-04-15T16:46:43.259083Z"
     }
    },
    "outputs": [],
@@ -175,22 +175,13 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:17.788068Z",
-     "iopub.status.busy": "2026-04-05T04:14:17.787866Z",
-     "iopub.status.idle": "2026-04-05T04:14:49.768836Z",
-     "shell.execute_reply": "2026-04-05T04:14:49.768114Z"
+     "iopub.execute_input": "2026-04-15T16:46:43.261354Z",
+     "iopub.status.busy": "2026-04-15T16:46:43.261182Z",
+     "iopub.status.idle": "2026-04-15T16:47:18.761683Z",
+     "shell.execute_reply": "2026-04-15T16:47:18.761143Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:210: DtypeWarning: Columns (8,10,14,21,27,29,30,33,35) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Query stations (can be slow)\n",
     "stations, site_md = wqp.what_sites(**query)"
@@ -201,10 +192,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:49.771388Z",
-     "iopub.status.busy": "2026-04-05T04:14:49.771153Z",
-     "iopub.status.idle": "2026-04-05T04:14:49.775367Z",
-     "shell.execute_reply": "2026-04-05T04:14:49.774823Z"
+     "iopub.execute_input": "2026-04-15T16:47:18.764189Z",
+     "iopub.status.busy": "2026-04-15T16:47:18.763972Z",
+     "iopub.status.idle": "2026-04-15T16:47:18.767879Z",
+     "shell.execute_reply": "2026-04-15T16:47:18.767385Z"
     }
    },
    "outputs": [
@@ -229,10 +220,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:49.777211Z",
-     "iopub.status.busy": "2026-04-05T04:14:49.777035Z",
-     "iopub.status.idle": "2026-04-05T04:14:49.793554Z",
-     "shell.execute_reply": "2026-04-05T04:14:49.792864Z"
+     "iopub.execute_input": "2026-04-15T16:47:18.769498Z",
+     "iopub.status.busy": "2026-04-15T16:47:18.769316Z",
+     "iopub.status.idle": "2026-04-15T16:47:18.783798Z",
+     "shell.execute_reply": "2026-04-15T16:47:18.783263Z"
     }
    },
    "outputs": [
@@ -495,10 +486,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:49.795456Z",
-     "iopub.status.busy": "2026-04-05T04:14:49.795239Z",
-     "iopub.status.idle": "2026-04-05T04:14:49.800331Z",
-     "shell.execute_reply": "2026-04-05T04:14:49.799801Z"
+     "iopub.execute_input": "2026-04-15T16:47:18.785520Z",
+     "iopub.status.busy": "2026-04-15T16:47:18.785349Z",
+     "iopub.status.idle": "2026-04-15T16:47:18.790390Z",
+     "shell.execute_reply": "2026-04-15T16:47:18.789797Z"
     }
    },
    "outputs": [
@@ -526,10 +517,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:49.802154Z",
-     "iopub.status.busy": "2026-04-05T04:14:49.801969Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.178814Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.178083Z"
+     "iopub.execute_input": "2026-04-15T16:47:18.792180Z",
+     "iopub.status.busy": "2026-04-15T16:47:18.791977Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.150565Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.149835Z"
     }
    },
    "outputs": [
@@ -560,10 +551,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.181185Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.180974Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.219875Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.219140Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.153024Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.152816Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.191917Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.191252Z"
     }
    },
    "outputs": [],
@@ -577,10 +568,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.221824Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.221627Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.225792Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.225116Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.194047Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.193847Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.197675Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.197097Z"
     }
    },
    "outputs": [
@@ -605,10 +596,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.227579Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.227386Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.233167Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.232473Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.199556Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.199364Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.204858Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.204285Z"
     }
    },
    "outputs": [
@@ -638,17 +629,17 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.235186Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.234991Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.239242Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.238547Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.206742Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.206546Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.210199Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.209729Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "<geopandas.array.GeometryDtype at 0x7fd88df9c160>"
+       "<geopandas.array.GeometryDtype at 0x7f8fdd333ca0>"
       ]
      },
      "execution_count": 13,
@@ -666,10 +657,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.241230Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.241032Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.246799Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.246244Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.211881Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.211713Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.217138Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.216545Z"
     }
    },
    "outputs": [
@@ -701,10 +692,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.248607Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.248407Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.785033Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.784267Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.218992Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.218808Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.727201Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.726601Z"
     }
    },
    "outputs": [
@@ -739,10 +730,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.787175Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.786983Z",
-     "iopub.status.idle": "2026-04-05T04:14:50.811057Z",
-     "shell.execute_reply": "2026-04-05T04:14:50.810388Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.729220Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.729013Z",
+     "iopub.status.idle": "2026-04-15T16:47:19.753836Z",
+     "shell.execute_reply": "2026-04-15T16:47:19.753352Z"
     }
    },
    "outputs": [],
@@ -756,10 +747,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:50.813212Z",
-     "iopub.status.busy": "2026-04-05T04:14:50.813029Z",
-     "iopub.status.idle": "2026-04-05T04:14:51.195121Z",
-     "shell.execute_reply": "2026-04-05T04:14:51.194541Z"
+     "iopub.execute_input": "2026-04-15T16:47:19.755762Z",
+     "iopub.status.busy": "2026-04-15T16:47:19.755563Z",
+     "iopub.status.idle": "2026-04-15T16:47:20.121100Z",
+     "shell.execute_reply": "2026-04-15T16:47:20.120492Z"
     }
    },
    "outputs": [
@@ -794,10 +785,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:51.197075Z",
-     "iopub.status.busy": "2026-04-05T04:14:51.196891Z",
-     "iopub.status.idle": "2026-04-05T04:14:51.200762Z",
-     "shell.execute_reply": "2026-04-05T04:14:51.200218Z"
+     "iopub.execute_input": "2026-04-15T16:47:20.122989Z",
+     "iopub.status.busy": "2026-04-15T16:47:20.122810Z",
+     "iopub.status.idle": "2026-04-15T16:47:20.126606Z",
+     "shell.execute_reply": "2026-04-15T16:47:20.126128Z"
     }
    },
    "outputs": [
@@ -822,10 +813,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:51.202557Z",
-     "iopub.status.busy": "2026-04-05T04:14:51.202381Z",
-     "iopub.status.idle": "2026-04-05T04:14:51.204813Z",
-     "shell.execute_reply": "2026-04-05T04:14:51.204283Z"
+     "iopub.execute_input": "2026-04-15T16:47:20.128469Z",
+     "iopub.status.busy": "2026-04-15T16:47:20.128265Z",
+     "iopub.status.idle": "2026-04-15T16:47:20.130723Z",
+     "shell.execute_reply": "2026-04-15T16:47:20.130237Z"
     }
    },
    "outputs": [],
@@ -848,22 +839,13 @@
    "execution_count": 20,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:14:51.206611Z",
-     "iopub.status.busy": "2026-04-05T04:14:51.206436Z",
-     "iopub.status.idle": "2026-04-05T04:38:36.840446Z",
-     "shell.execute_reply": "2026-04-05T04:38:36.839731Z"
+     "iopub.execute_input": "2026-04-15T16:47:20.132412Z",
+     "iopub.status.busy": "2026-04-15T16:47:20.132245Z",
+     "iopub.status.idle": "2026-04-15T17:11:20.184356Z",
+     "shell.execute_reply": "2026-04-15T17:11:20.183782Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:153: DtypeWarning: Columns (9,10,13,15,17,19,22,23,28,31,33,36,38,58,60,61,62,64,65,70,71,73) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Now query for results\n",
     "query['dataProfile'] = 'narrowResult'\n",
@@ -875,10 +857,10 @@
    "execution_count": 21,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:36.842968Z",
-     "iopub.status.busy": "2026-04-05T04:38:36.842763Z",
-     "iopub.status.idle": "2026-04-05T04:38:37.308351Z",
-     "shell.execute_reply": "2026-04-05T04:38:37.307587Z"
+     "iopub.execute_input": "2026-04-15T17:11:20.186921Z",
+     "iopub.status.busy": "2026-04-15T17:11:20.186722Z",
+     "iopub.status.idle": "2026-04-15T17:11:20.625653Z",
+     "shell.execute_reply": "2026-04-15T17:11:20.625005Z"
     }
    },
    "outputs": [
@@ -1358,10 +1340,10 @@
    "execution_count": 22,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:37.310584Z",
-     "iopub.status.busy": "2026-04-05T04:38:37.310396Z",
-     "iopub.status.idle": "2026-04-05T04:38:38.735273Z",
-     "shell.execute_reply": "2026-04-05T04:38:38.734531Z"
+     "iopub.execute_input": "2026-04-15T17:11:20.627662Z",
+     "iopub.status.busy": "2026-04-15T17:11:20.627471Z",
+     "iopub.status.idle": "2026-04-15T17:11:21.985464Z",
+     "shell.execute_reply": "2026-04-15T17:11:21.984770Z"
     }
    },
    "outputs": [
@@ -1412,10 +1394,10 @@
    "execution_count": 23,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:38.737545Z",
-     "iopub.status.busy": "2026-04-05T04:38:38.737235Z",
-     "iopub.status.idle": "2026-04-05T04:38:38.740233Z",
-     "shell.execute_reply": "2026-04-05T04:38:38.739533Z"
+     "iopub.execute_input": "2026-04-15T17:11:21.987763Z",
+     "iopub.status.busy": "2026-04-15T17:11:21.987470Z",
+     "iopub.status.idle": "2026-04-15T17:11:21.990230Z",
+     "shell.execute_reply": "2026-04-15T17:11:21.989621Z"
     }
    },
    "outputs": [],
@@ -1437,10 +1419,10 @@
    "execution_count": 24,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:38.742062Z",
-     "iopub.status.busy": "2026-04-05T04:38:38.741868Z",
-     "iopub.status.idle": "2026-04-05T04:38:44.430013Z",
-     "shell.execute_reply": "2026-04-05T04:38:44.429309Z"
+     "iopub.execute_input": "2026-04-15T17:11:21.992002Z",
+     "iopub.status.busy": "2026-04-15T17:11:21.991831Z",
+     "iopub.status.idle": "2026-04-15T17:11:26.780309Z",
+     "shell.execute_reply": "2026-04-15T17:11:26.779664Z"
     },
     "scrolled": true
    },
@@ -1465,7 +1447,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.8, 'meter')> <Quantity(2.2, 'meter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.8, 'meter')> <Quantity(2.2, 'meter')>\n",
       " <Quantity(2.7, 'meter')> ... <Quantity(2.4, 'meter')>\n",
       " <Quantity(1.8, 'meter')> <Quantity(3.3, 'meter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1521,10 +1503,10 @@
    "execution_count": 25,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:44.432067Z",
-     "iopub.status.busy": "2026-04-05T04:38:44.431875Z",
-     "iopub.status.idle": "2026-04-05T04:38:44.573408Z",
-     "shell.execute_reply": "2026-04-05T04:38:44.572572Z"
+     "iopub.execute_input": "2026-04-15T17:11:26.782335Z",
+     "iopub.status.busy": "2026-04-15T17:11:26.782140Z",
+     "iopub.status.idle": "2026-04-15T17:11:26.925848Z",
+     "shell.execute_reply": "2026-04-15T17:11:26.925221Z"
     }
    },
    "outputs": [
@@ -1709,10 +1691,10 @@
    "execution_count": 26,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:44.575522Z",
-     "iopub.status.busy": "2026-04-05T04:38:44.575288Z",
-     "iopub.status.idle": "2026-04-05T04:38:44.615686Z",
-     "shell.execute_reply": "2026-04-05T04:38:44.615040Z"
+     "iopub.execute_input": "2026-04-15T17:11:26.927784Z",
+     "iopub.status.busy": "2026-04-15T17:11:26.927584Z",
+     "iopub.status.idle": "2026-04-15T17:11:26.968072Z",
+     "shell.execute_reply": "2026-04-15T17:11:26.967444Z"
     }
    },
    "outputs": [
@@ -1908,10 +1890,10 @@
    "execution_count": 27,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:44.617693Z",
-     "iopub.status.busy": "2026-04-05T04:38:44.617483Z",
-     "iopub.status.idle": "2026-04-05T04:38:44.652272Z",
-     "shell.execute_reply": "2026-04-05T04:38:44.651725Z"
+     "iopub.execute_input": "2026-04-15T17:11:26.969958Z",
+     "iopub.status.busy": "2026-04-15T17:11:26.969761Z",
+     "iopub.status.idle": "2026-04-15T17:11:27.006179Z",
+     "shell.execute_reply": "2026-04-15T17:11:27.005598Z"
     }
    },
    "outputs": [
@@ -1936,10 +1918,10 @@
    "execution_count": 28,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:44.654222Z",
-     "iopub.status.busy": "2026-04-05T04:38:44.654030Z",
-     "iopub.status.idle": "2026-04-05T04:38:44.688447Z",
-     "shell.execute_reply": "2026-04-05T04:38:44.687726Z"
+     "iopub.execute_input": "2026-04-15T17:11:27.008045Z",
+     "iopub.status.busy": "2026-04-15T17:11:27.007858Z",
+     "iopub.status.idle": "2026-04-15T17:11:27.041988Z",
+     "shell.execute_reply": "2026-04-15T17:11:27.041452Z"
     }
    },
    "outputs": [
@@ -2142,10 +2124,10 @@
    "execution_count": 29,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:44.690465Z",
-     "iopub.status.busy": "2026-04-05T04:38:44.690252Z",
-     "iopub.status.idle": "2026-04-05T04:38:44.771669Z",
-     "shell.execute_reply": "2026-04-05T04:38:44.771008Z"
+     "iopub.execute_input": "2026-04-15T17:11:27.043908Z",
+     "iopub.status.busy": "2026-04-15T17:11:27.043702Z",
+     "iopub.status.idle": "2026-04-15T17:11:27.120075Z",
+     "shell.execute_reply": "2026-04-15T17:11:27.119464Z"
     }
    },
    "outputs": [
@@ -2279,10 +2261,10 @@
    "execution_count": 30,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:44.773605Z",
-     "iopub.status.busy": "2026-04-05T04:38:44.773420Z",
-     "iopub.status.idle": "2026-04-05T04:38:45.454985Z",
-     "shell.execute_reply": "2026-04-05T04:38:45.454192Z"
+     "iopub.execute_input": "2026-04-15T17:11:27.122043Z",
+     "iopub.status.busy": "2026-04-15T17:11:27.121860Z",
+     "iopub.status.idle": "2026-04-15T17:11:27.779920Z",
+     "shell.execute_reply": "2026-04-15T17:11:27.779315Z"
     }
    },
    "outputs": [
@@ -2326,10 +2308,10 @@
    "execution_count": 31,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:45.457043Z",
-     "iopub.status.busy": "2026-04-05T04:38:45.456833Z",
-     "iopub.status.idle": "2026-04-05T04:38:46.217409Z",
-     "shell.execute_reply": "2026-04-05T04:38:46.216665Z"
+     "iopub.execute_input": "2026-04-15T17:11:27.781990Z",
+     "iopub.status.busy": "2026-04-15T17:11:27.781769Z",
+     "iopub.status.idle": "2026-04-15T17:11:28.497535Z",
+     "shell.execute_reply": "2026-04-15T17:11:28.496851Z"
     }
    },
    "outputs": [
@@ -2379,10 +2361,10 @@
    "execution_count": 32,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:46.219572Z",
-     "iopub.status.busy": "2026-04-05T04:38:46.219383Z",
-     "iopub.status.idle": "2026-04-05T04:38:52.337859Z",
-     "shell.execute_reply": "2026-04-05T04:38:52.337059Z"
+     "iopub.execute_input": "2026-04-15T17:11:28.499536Z",
+     "iopub.status.busy": "2026-04-15T17:11:28.499339Z",
+     "iopub.status.idle": "2026-04-15T17:11:34.191717Z",
+     "shell.execute_reply": "2026-04-15T17:11:34.191066Z"
     }
    },
    "outputs": [
@@ -2398,7 +2380,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(28.19, 'degree_Celsius')> <Quantity(29.52, 'degree_Celsius')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(28.19, 'degree_Celsius')> <Quantity(29.52, 'degree_Celsius')>\n",
       " <Quantity(21.0, 'degree_Celsius')> ... <Quantity(31.2, 'degree_Celsius')>\n",
       " <Quantity(14.1, 'degree_Celsius')> <Quantity(31.1, 'degree_Celsius')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -2445,10 +2427,10 @@
    "execution_count": 33,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:52.340084Z",
-     "iopub.status.busy": "2026-04-05T04:38:52.339875Z",
-     "iopub.status.idle": "2026-04-05T04:38:52.495584Z",
-     "shell.execute_reply": "2026-04-05T04:38:52.494814Z"
+     "iopub.execute_input": "2026-04-15T17:11:34.193611Z",
+     "iopub.status.busy": "2026-04-15T17:11:34.193431Z",
+     "iopub.status.idle": "2026-04-15T17:11:34.348314Z",
+     "shell.execute_reply": "2026-04-15T17:11:34.347628Z"
     }
    },
    "outputs": [
@@ -2640,10 +2622,10 @@
    "execution_count": 34,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:52.497916Z",
-     "iopub.status.busy": "2026-04-05T04:38:52.497690Z",
-     "iopub.status.idle": "2026-04-05T04:38:52.548607Z",
-     "shell.execute_reply": "2026-04-05T04:38:52.547846Z"
+     "iopub.execute_input": "2026-04-15T17:11:34.350518Z",
+     "iopub.status.busy": "2026-04-15T17:11:34.350246Z",
+     "iopub.status.idle": "2026-04-15T17:11:34.402120Z",
+     "shell.execute_reply": "2026-04-15T17:11:34.401458Z"
     }
    },
    "outputs": [
@@ -2846,10 +2828,10 @@
    "execution_count": 35,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:52.550697Z",
-     "iopub.status.busy": "2026-04-05T04:38:52.550482Z",
-     "iopub.status.idle": "2026-04-05T04:38:52.597504Z",
-     "shell.execute_reply": "2026-04-05T04:38:52.596704Z"
+     "iopub.execute_input": "2026-04-15T17:11:34.404178Z",
+     "iopub.status.busy": "2026-04-15T17:11:34.403959Z",
+     "iopub.status.idle": "2026-04-15T17:11:34.451592Z",
+     "shell.execute_reply": "2026-04-15T17:11:34.451079Z"
     }
    },
    "outputs": [
@@ -2874,10 +2856,10 @@
    "execution_count": 36,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:52.599552Z",
-     "iopub.status.busy": "2026-04-05T04:38:52.599343Z",
-     "iopub.status.idle": "2026-04-05T04:38:52.652071Z",
-     "shell.execute_reply": "2026-04-05T04:38:52.651348Z"
+     "iopub.execute_input": "2026-04-15T17:11:34.453424Z",
+     "iopub.status.busy": "2026-04-15T17:11:34.453241Z",
+     "iopub.status.idle": "2026-04-15T17:11:34.507998Z",
+     "shell.execute_reply": "2026-04-15T17:11:34.507407Z"
     }
    },
    "outputs": [
@@ -3073,10 +3055,10 @@
    "execution_count": 37,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:52.654099Z",
-     "iopub.status.busy": "2026-04-05T04:38:52.653878Z",
-     "iopub.status.idle": "2026-04-05T04:38:52.898923Z",
-     "shell.execute_reply": "2026-04-05T04:38:52.898141Z"
+     "iopub.execute_input": "2026-04-15T17:11:34.509799Z",
+     "iopub.status.busy": "2026-04-15T17:11:34.509598Z",
+     "iopub.status.idle": "2026-04-15T17:11:34.740438Z",
+     "shell.execute_reply": "2026-04-15T17:11:34.739772Z"
     }
    },
    "outputs": [
@@ -3210,10 +3192,10 @@
    "execution_count": 38,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:52.901047Z",
-     "iopub.status.busy": "2026-04-05T04:38:52.900854Z",
-     "iopub.status.idle": "2026-04-05T04:38:53.713667Z",
-     "shell.execute_reply": "2026-04-05T04:38:53.713028Z"
+     "iopub.execute_input": "2026-04-15T17:11:34.742435Z",
+     "iopub.status.busy": "2026-04-15T17:11:34.742235Z",
+     "iopub.status.idle": "2026-04-15T17:11:35.519559Z",
+     "shell.execute_reply": "2026-04-15T17:11:35.518899Z"
     }
    },
    "outputs": [
@@ -3257,10 +3239,10 @@
    "execution_count": 39,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:53.715737Z",
-     "iopub.status.busy": "2026-04-05T04:38:53.715545Z",
-     "iopub.status.idle": "2026-04-05T04:38:54.756910Z",
-     "shell.execute_reply": "2026-04-05T04:38:54.756271Z"
+     "iopub.execute_input": "2026-04-15T17:11:35.521430Z",
+     "iopub.status.busy": "2026-04-15T17:11:35.521252Z",
+     "iopub.status.idle": "2026-04-15T17:11:36.502560Z",
+     "shell.execute_reply": "2026-04-15T17:11:36.501852Z"
     }
    },
    "outputs": [
@@ -3303,10 +3285,10 @@
    "execution_count": 40,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:38:54.759034Z",
-     "iopub.status.busy": "2026-04-05T04:38:54.758844Z",
-     "iopub.status.idle": "2026-04-05T04:39:33.598036Z",
-     "shell.execute_reply": "2026-04-05T04:39:33.597328Z"
+     "iopub.execute_input": "2026-04-15T17:11:36.504545Z",
+     "iopub.status.busy": "2026-04-15T17:11:36.504351Z",
+     "iopub.status.idle": "2026-04-15T17:12:07.895782Z",
+     "shell.execute_reply": "2026-04-15T17:12:07.895212Z"
     }
    },
    "outputs": [
@@ -3322,7 +3304,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(9.32, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(9.32, 'milligram / liter')>\n",
       " <Quantity(8.08, 'milligram / liter')>\n",
       " <Quantity(4.9, 'milligram / liter')> ...\n",
       " <Quantity(8.2, 'milligram / liter')> <Quantity(7.9, 'milligram / liter')>\n",
@@ -3348,10 +3330,10 @@
    "execution_count": 41,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:33.600553Z",
-     "iopub.status.busy": "2026-04-05T04:39:33.600274Z",
-     "iopub.status.idle": "2026-04-05T04:39:33.747756Z",
-     "shell.execute_reply": "2026-04-05T04:39:33.747027Z"
+     "iopub.execute_input": "2026-04-15T17:12:07.898186Z",
+     "iopub.status.busy": "2026-04-15T17:12:07.897937Z",
+     "iopub.status.idle": "2026-04-15T17:12:08.043207Z",
+     "shell.execute_reply": "2026-04-15T17:12:08.042542Z"
     }
    },
    "outputs": [
@@ -3537,10 +3519,10 @@
    "execution_count": 42,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:33.749859Z",
-     "iopub.status.busy": "2026-04-05T04:39:33.749629Z",
-     "iopub.status.idle": "2026-04-05T04:39:33.786644Z",
-     "shell.execute_reply": "2026-04-05T04:39:33.785887Z"
+     "iopub.execute_input": "2026-04-15T17:12:08.045334Z",
+     "iopub.status.busy": "2026-04-15T17:12:08.045097Z",
+     "iopub.status.idle": "2026-04-15T17:12:08.076878Z",
+     "shell.execute_reply": "2026-04-15T17:12:08.076344Z"
     }
    },
    "outputs": [
@@ -3730,10 +3712,10 @@
    "execution_count": 43,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:33.788812Z",
-     "iopub.status.busy": "2026-04-05T04:39:33.788609Z",
-     "iopub.status.idle": "2026-04-05T04:39:34.017979Z",
-     "shell.execute_reply": "2026-04-05T04:39:34.017360Z"
+     "iopub.execute_input": "2026-04-15T17:12:08.078732Z",
+     "iopub.status.busy": "2026-04-15T17:12:08.078554Z",
+     "iopub.status.idle": "2026-04-15T17:12:08.300692Z",
+     "shell.execute_reply": "2026-04-15T17:12:08.300066Z"
     }
    },
    "outputs": [
@@ -3867,10 +3849,10 @@
    "execution_count": 44,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:34.019876Z",
-     "iopub.status.busy": "2026-04-05T04:39:34.019675Z",
-     "iopub.status.idle": "2026-04-05T04:39:35.118875Z",
-     "shell.execute_reply": "2026-04-05T04:39:35.118154Z"
+     "iopub.execute_input": "2026-04-15T17:12:08.302706Z",
+     "iopub.status.busy": "2026-04-15T17:12:08.302506Z",
+     "iopub.status.idle": "2026-04-15T17:12:09.382903Z",
+     "shell.execute_reply": "2026-04-15T17:12:09.382245Z"
     }
    },
    "outputs": [
@@ -3914,10 +3896,10 @@
    "execution_count": 45,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:35.120900Z",
-     "iopub.status.busy": "2026-04-05T04:39:35.120704Z",
-     "iopub.status.idle": "2026-04-05T04:39:36.124093Z",
-     "shell.execute_reply": "2026-04-05T04:39:36.123380Z"
+     "iopub.execute_input": "2026-04-15T17:12:09.384868Z",
+     "iopub.status.busy": "2026-04-15T17:12:09.384665Z",
+     "iopub.status.idle": "2026-04-15T17:12:10.332527Z",
+     "shell.execute_reply": "2026-04-15T17:12:10.331875Z"
     }
    },
    "outputs": [
@@ -3960,10 +3942,10 @@
    "execution_count": 46,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:36.126267Z",
-     "iopub.status.busy": "2026-04-05T04:39:36.126072Z",
-     "iopub.status.idle": "2026-04-05T04:39:43.649965Z",
-     "shell.execute_reply": "2026-04-05T04:39:43.649130Z"
+     "iopub.execute_input": "2026-04-15T17:12:10.334469Z",
+     "iopub.status.busy": "2026-04-15T17:12:10.334274Z",
+     "iopub.status.idle": "2026-04-15T17:12:17.127525Z",
+     "shell.execute_reply": "2026-04-15T17:12:17.126873Z"
     }
    },
    "outputs": [
@@ -3979,7 +3961,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.48, 'dimensionless')> <Quantity(8.18, 'dimensionless')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.48, 'dimensionless')> <Quantity(8.18, 'dimensionless')>\n",
       " <Quantity(7.81, 'dimensionless')> ... <Quantity(7.8, 'dimensionless')>\n",
       " <Quantity(7.7, 'dimensionless')> <Quantity(7.6, 'dimensionless')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -4032,10 +4014,10 @@
    "execution_count": 47,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:43.652245Z",
-     "iopub.status.busy": "2026-04-05T04:39:43.652037Z",
-     "iopub.status.idle": "2026-04-05T04:39:43.783916Z",
-     "shell.execute_reply": "2026-04-05T04:39:43.783265Z"
+     "iopub.execute_input": "2026-04-15T17:12:17.129647Z",
+     "iopub.status.busy": "2026-04-15T17:12:17.129442Z",
+     "iopub.status.idle": "2026-04-15T17:12:17.260287Z",
+     "shell.execute_reply": "2026-04-15T17:12:17.259604Z"
     }
    },
    "outputs": [
@@ -4207,10 +4189,10 @@
    "execution_count": 48,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:39:43.786032Z",
-     "iopub.status.busy": "2026-04-05T04:39:43.785825Z",
-     "iopub.status.idle": "2026-04-05T04:40:16.537993Z",
-     "shell.execute_reply": "2026-04-05T04:40:16.537323Z"
+     "iopub.execute_input": "2026-04-15T17:12:17.262563Z",
+     "iopub.status.busy": "2026-04-15T17:12:17.262345Z",
+     "iopub.status.idle": "2026-04-15T17:12:41.981382Z",
+     "shell.execute_reply": "2026-04-15T17:12:41.980699Z"
     }
    },
    "outputs": [
@@ -4234,7 +4216,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:510: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:513: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  self.df[c_mask] = basis.update_result_basis(\n"
      ]
     },
@@ -4242,7 +4224,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(40.0, 'Practical_Salinity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(40.0, 'Practical_Salinity_Units')>\n",
       " <Quantity(29.0, 'Practical_Salinity_Units')>\n",
       " <Quantity(26.04, 'Practical_Salinity_Units')> ...\n",
       " <Quantity(31.3, 'Practical_Salinity_Units')>\n",
@@ -4291,10 +4273,10 @@
    "execution_count": 49,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:16.539964Z",
-     "iopub.status.busy": "2026-04-05T04:40:16.539765Z",
-     "iopub.status.idle": "2026-04-05T04:40:16.687463Z",
-     "shell.execute_reply": "2026-04-05T04:40:16.686857Z"
+     "iopub.execute_input": "2026-04-15T17:12:41.983277Z",
+     "iopub.status.busy": "2026-04-15T17:12:41.983060Z",
+     "iopub.status.idle": "2026-04-15T17:12:42.123039Z",
+     "shell.execute_reply": "2026-04-15T17:12:42.122416Z"
     }
    },
    "outputs": [
@@ -4377,7 +4359,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1537973</th>\n",
-       "      <td>28.0</td>\n",
+       "      <td>28</td>\n",
        "      <td>PSS</td>\n",
        "      <td>NaN</td>\n",
        "      <td>28.0 Practical_Salinity_Units</td>\n",
@@ -4391,14 +4373,14 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1537975</th>\n",
-       "      <td>29.0</td>\n",
+       "      <td>29</td>\n",
        "      <td>PSS</td>\n",
        "      <td>NaN</td>\n",
        "      <td>29.0 Practical_Salinity_Units</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1537976</th>\n",
-       "      <td>28.0</td>\n",
+       "      <td>28</td>\n",
        "      <td>PSS</td>\n",
        "      <td>NaN</td>\n",
        "      <td>28.0 Practical_Salinity_Units</td>\n",
@@ -4417,10 +4399,10 @@
        "23                     5.9                          ppth     NaN   \n",
        "...                    ...                           ...     ...   \n",
        "1537967               27.8                           PSS     NaN   \n",
-       "1537973               28.0                           PSS     NaN   \n",
+       "1537973                 28                           PSS     NaN   \n",
        "1537974               31.3                           PSS     NaN   \n",
-       "1537975               29.0                           PSS     NaN   \n",
-       "1537976               28.0                           PSS     NaN   \n",
+       "1537975                 29                           PSS     NaN   \n",
+       "1537976                 28                           PSS     NaN   \n",
        "\n",
        "                               Salinity  \n",
        "1         40.0 Practical_Salinity_Units  \n",
@@ -4460,10 +4442,10 @@
    "execution_count": 50,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:16.689660Z",
-     "iopub.status.busy": "2026-04-05T04:40:16.689448Z",
-     "iopub.status.idle": "2026-04-05T04:40:23.823754Z",
-     "shell.execute_reply": "2026-04-05T04:40:23.823013Z"
+     "iopub.execute_input": "2026-04-15T17:12:42.125168Z",
+     "iopub.status.busy": "2026-04-15T17:12:42.124943Z",
+     "iopub.status.idle": "2026-04-15T17:12:48.125875Z",
+     "shell.execute_reply": "2026-04-15T17:12:48.125221Z"
     }
    },
    "outputs": [
@@ -4504,7 +4486,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.39, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.39, 'milligram / liter')>\n",
       " <Quantity(0.4475, 'milligram / liter')>\n",
       " <Quantity(0.425, 'milligram / liter')>\n",
       " <Quantity(0.4625, 'milligram / liter')>\n",
@@ -4667,19 +4649,19 @@
       " <Quantity(0.091, 'milligram / liter')>\n",
       " <Quantity(0.057, 'milligram / liter')>\n",
       " <Quantity(0.03, 'milligram / liter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
-      "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
+      "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
+      "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
-      "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
-      "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
-      "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/domains.py:277: FutureWarning: Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`\n",
       "  sub_df[cols[2]] = sub_df[cols[2]].fillna(sub_df[cols[1]])  # new_fract\n"
      ]
@@ -4724,10 +4706,10 @@
    "execution_count": 51,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:23.825714Z",
-     "iopub.status.busy": "2026-04-05T04:40:23.825530Z",
-     "iopub.status.idle": "2026-04-05T04:40:23.940514Z",
-     "shell.execute_reply": "2026-04-05T04:40:23.939817Z"
+     "iopub.execute_input": "2026-04-15T17:12:48.127931Z",
+     "iopub.status.busy": "2026-04-15T17:12:48.127730Z",
+     "iopub.status.idle": "2026-04-15T17:12:48.243937Z",
+     "shell.execute_reply": "2026-04-15T17:12:48.243268Z"
     }
    },
    "outputs": [
@@ -4831,7 +4813,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1535842</th>\n",
-       "      <td>0.03</td>\n",
+       "      <td>0.030</td>\n",
        "      <td>mg/l</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.03 milligram / liter</td>\n",
@@ -4853,7 +4835,7 @@
        "1535643              0.166                          mg/l     NaN   \n",
        "1535653              0.091                          mg/l     NaN   \n",
        "1535687              0.057                          mg/l     NaN   \n",
-       "1535842               0.03                          mg/l     NaN   \n",
+       "1535842              0.030                          mg/l     NaN   \n",
        "\n",
        "                          Nitrogen  \n",
        "262029      0.39 milligram / liter  \n",
@@ -4893,10 +4875,10 @@
    "execution_count": 52,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:23.942510Z",
-     "iopub.status.busy": "2026-04-05T04:40:23.942288Z",
-     "iopub.status.idle": "2026-04-05T04:40:27.822081Z",
-     "shell.execute_reply": "2026-04-05T04:40:27.821471Z"
+     "iopub.execute_input": "2026-04-15T17:12:48.245970Z",
+     "iopub.status.busy": "2026-04-15T17:12:48.245759Z",
+     "iopub.status.idle": "2026-04-15T17:12:51.753372Z",
+     "shell.execute_reply": "2026-04-15T17:12:51.752724Z"
     }
    },
    "outputs": [
@@ -4912,7 +4894,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(626.0, 'microsiemens / centimeter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(626.0, 'microsiemens / centimeter')>\n",
       " <Quantity(688.0, 'microsiemens / centimeter')>\n",
       " <Quantity(606.0, 'microsiemens / centimeter')>\n",
       " <Quantity(606.0, 'microsiemens / centimeter')>\n",
@@ -4966,10 +4948,10 @@
    "execution_count": 53,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:27.824038Z",
-     "iopub.status.busy": "2026-04-05T04:40:27.823852Z",
-     "iopub.status.idle": "2026-04-05T04:40:27.938491Z",
-     "shell.execute_reply": "2026-04-05T04:40:27.937775Z"
+     "iopub.execute_input": "2026-04-15T17:12:51.755264Z",
+     "iopub.status.busy": "2026-04-15T17:12:51.755063Z",
+     "iopub.status.idle": "2026-04-15T17:12:51.867546Z",
+     "shell.execute_reply": "2026-04-15T17:12:51.866900Z"
     }
    },
    "outputs": [
@@ -5225,10 +5207,10 @@
    "execution_count": 54,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:27.940759Z",
-     "iopub.status.busy": "2026-04-05T04:40:27.940550Z",
-     "iopub.status.idle": "2026-04-05T04:40:40.714884Z",
-     "shell.execute_reply": "2026-04-05T04:40:40.714256Z"
+     "iopub.execute_input": "2026-04-15T17:12:51.869567Z",
+     "iopub.status.busy": "2026-04-15T17:12:51.869375Z",
+     "iopub.status.idle": "2026-04-15T17:13:02.556990Z",
+     "shell.execute_reply": "2026-04-15T17:13:02.556372Z"
     }
    },
    "outputs": [
@@ -5244,7 +5226,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.00594, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.00594, 'milligram / liter')>\n",
       " <Quantity(0.00145, 'milligram / liter')>\n",
       " <Quantity(0.00277, 'milligram / liter')> ...\n",
       " <Quantity(0.00741, 'milligram / liter')>\n",
@@ -5293,10 +5275,10 @@
    "execution_count": 55,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:40.716852Z",
-     "iopub.status.busy": "2026-04-05T04:40:40.716651Z",
-     "iopub.status.idle": "2026-04-05T04:40:40.836139Z",
-     "shell.execute_reply": "2026-04-05T04:40:40.835424Z"
+     "iopub.execute_input": "2026-04-15T17:13:02.559005Z",
+     "iopub.status.busy": "2026-04-15T17:13:02.558820Z",
+     "iopub.status.idle": "2026-04-15T17:13:02.675363Z",
+     "shell.execute_reply": "2026-04-15T17:13:02.674680Z"
     }
    },
    "outputs": [
@@ -5462,10 +5444,10 @@
    "execution_count": 56,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:40.838174Z",
-     "iopub.status.busy": "2026-04-05T04:40:40.837972Z",
-     "iopub.status.idle": "2026-04-05T04:40:52.544909Z",
-     "shell.execute_reply": "2026-04-05T04:40:52.544131Z"
+     "iopub.execute_input": "2026-04-15T17:13:02.677341Z",
+     "iopub.status.busy": "2026-04-15T17:13:02.677148Z",
+     "iopub.status.idle": "2026-04-15T17:13:12.737264Z",
+     "shell.execute_reply": "2026-04-15T17:13:12.736605Z"
     }
    },
    "outputs": [
@@ -5481,7 +5463,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.8, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.8, 'milligram / liter')>\n",
       " <Quantity(19.5, 'milligram / liter')>\n",
       " <Quantity(11.3, 'milligram / liter')> ...\n",
       " <Quantity(4.8, 'milligram / liter')>\n",
@@ -5530,10 +5512,10 @@
    "execution_count": 57,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:52.547076Z",
-     "iopub.status.busy": "2026-04-05T04:40:52.546869Z",
-     "iopub.status.idle": "2026-04-05T04:40:52.666875Z",
-     "shell.execute_reply": "2026-04-05T04:40:52.666223Z"
+     "iopub.execute_input": "2026-04-15T17:13:12.739196Z",
+     "iopub.status.busy": "2026-04-15T17:13:12.738992Z",
+     "iopub.status.idle": "2026-04-15T17:13:12.857121Z",
+     "shell.execute_reply": "2026-04-15T17:13:12.856465Z"
     }
    },
    "outputs": [
@@ -5623,7 +5605,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1533879</th>\n",
-       "      <td>4.8</td>\n",
+       "      <td>4.80</td>\n",
        "      <td>mg/l</td>\n",
        "      <td>NaN</td>\n",
        "      <td>4.8 milligram / liter</td>\n",
@@ -5637,7 +5619,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1533889</th>\n",
-       "      <td>3.7</td>\n",
+       "      <td>3.70</td>\n",
        "      <td>mg/l</td>\n",
        "      <td>NaN</td>\n",
        "      <td>3.7 milligram / liter</td>\n",
@@ -5657,9 +5639,9 @@
        "...                    ...                           ...     ...   \n",
        "1533869               4.53                          mg/l     NaN   \n",
        "1533874               1.56                          mg/l     NaN   \n",
-       "1533879                4.8                          mg/l     NaN   \n",
+       "1533879               4.80                          mg/l     NaN   \n",
        "1533884               12.9                          mg/l     NaN   \n",
-       "1533889                3.7                          mg/l     NaN   \n",
+       "1533889               3.70                          mg/l     NaN   \n",
        "\n",
        "                         Carbon  \n",
        "3         3.8 milligram / liter  \n",
@@ -5699,10 +5681,10 @@
    "execution_count": 58,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:40:52.668961Z",
-     "iopub.status.busy": "2026-04-05T04:40:52.668725Z",
-     "iopub.status.idle": "2026-04-05T04:41:01.694487Z",
-     "shell.execute_reply": "2026-04-05T04:41:01.693716Z"
+     "iopub.execute_input": "2026-04-15T17:13:12.859244Z",
+     "iopub.status.busy": "2026-04-15T17:13:12.859023Z",
+     "iopub.status.idle": "2026-04-15T17:13:21.194297Z",
+     "shell.execute_reply": "2026-04-15T17:13:21.193651Z"
     }
    },
    "outputs": [
@@ -5718,7 +5700,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.49, 'Nephelometric_Turbidity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.49, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(1.2, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(2.9, 'Nephelometric_Turbidity_Units')> ...\n",
       " <Quantity(0.7, 'Nephelometric_Turbidity_Units')>\n",
@@ -5767,10 +5749,10 @@
    "execution_count": 59,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:01.696586Z",
-     "iopub.status.busy": "2026-04-05T04:41:01.696395Z",
-     "iopub.status.idle": "2026-04-05T04:41:01.823025Z",
-     "shell.execute_reply": "2026-04-05T04:41:01.822386Z"
+     "iopub.execute_input": "2026-04-15T17:13:21.196246Z",
+     "iopub.status.busy": "2026-04-15T17:13:21.196041Z",
+     "iopub.status.idle": "2026-04-15T17:13:21.318144Z",
+     "shell.execute_reply": "2026-04-15T17:13:21.317502Z"
     }
    },
    "outputs": [
@@ -5936,10 +5918,10 @@
    "execution_count": 60,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:01.825207Z",
-     "iopub.status.busy": "2026-04-05T04:41:01.824983Z",
-     "iopub.status.idle": "2026-04-05T04:41:05.248341Z",
-     "shell.execute_reply": "2026-04-05T04:41:05.247579Z"
+     "iopub.execute_input": "2026-04-15T17:13:21.320210Z",
+     "iopub.status.busy": "2026-04-15T17:13:21.319994Z",
+     "iopub.status.idle": "2026-04-15T17:13:24.384405Z",
+     "shell.execute_reply": "2026-04-15T17:13:24.383805Z"
     }
    },
    "outputs": [
@@ -5955,7 +5937,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
      ]
     }
@@ -5970,10 +5952,10 @@
    "execution_count": 61,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:05.250791Z",
-     "iopub.status.busy": "2026-04-05T04:41:05.250558Z",
-     "iopub.status.idle": "2026-04-05T04:41:05.366525Z",
-     "shell.execute_reply": "2026-04-05T04:41:05.365719Z"
+     "iopub.execute_input": "2026-04-15T17:13:24.386745Z",
+     "iopub.status.busy": "2026-04-15T17:13:24.386527Z",
+     "iopub.status.idle": "2026-04-15T17:13:24.501230Z",
+     "shell.execute_reply": "2026-04-15T17:13:24.500604Z"
     }
    },
    "outputs": [
@@ -6044,10 +6026,10 @@
    "execution_count": 62,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:05.368815Z",
-     "iopub.status.busy": "2026-04-05T04:41:05.368608Z",
-     "iopub.status.idle": "2026-04-05T04:41:19.869777Z",
-     "shell.execute_reply": "2026-04-05T04:41:19.869117Z"
+     "iopub.execute_input": "2026-04-15T17:13:24.503412Z",
+     "iopub.status.busy": "2026-04-15T17:13:24.503209Z",
+     "iopub.status.idle": "2026-04-15T17:13:37.052380Z",
+     "shell.execute_reply": "2026-04-15T17:13:37.051603Z"
     }
    },
    "outputs": [
@@ -6063,7 +6045,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
       " <Quantity(0.004, 'milligram / liter')>\n",
       " <Quantity(0.049, 'milligram / liter')> ...\n",
       " <Quantity(0.04, 'milligram / liter')>\n",
@@ -6104,10 +6086,10 @@
    "execution_count": 63,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:19.872118Z",
-     "iopub.status.busy": "2026-04-05T04:41:19.871906Z",
-     "iopub.status.idle": "2026-04-05T04:41:19.947692Z",
-     "shell.execute_reply": "2026-04-05T04:41:19.947005Z"
+     "iopub.execute_input": "2026-04-15T17:13:37.054873Z",
+     "iopub.status.busy": "2026-04-15T17:13:37.054650Z",
+     "iopub.status.idle": "2026-04-15T17:13:37.126036Z",
+     "shell.execute_reply": "2026-04-15T17:13:37.125383Z"
     }
    },
    "outputs": [
@@ -6267,10 +6249,10 @@
    "execution_count": 64,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:19.949685Z",
-     "iopub.status.busy": "2026-04-05T04:41:19.949500Z",
-     "iopub.status.idle": "2026-04-05T04:41:20.022460Z",
-     "shell.execute_reply": "2026-04-05T04:41:20.021744Z"
+     "iopub.execute_input": "2026-04-15T17:13:37.128055Z",
+     "iopub.status.busy": "2026-04-15T17:13:37.127863Z",
+     "iopub.status.idle": "2026-04-15T17:13:37.196940Z",
+     "shell.execute_reply": "2026-04-15T17:13:37.196298Z"
     }
    },
    "outputs": [
@@ -6429,10 +6411,10 @@
    "execution_count": 65,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:20.024441Z",
-     "iopub.status.busy": "2026-04-05T04:41:20.024220Z",
-     "iopub.status.idle": "2026-04-05T04:41:20.094078Z",
-     "shell.execute_reply": "2026-04-05T04:41:20.093322Z"
+     "iopub.execute_input": "2026-04-15T17:13:37.198909Z",
+     "iopub.status.busy": "2026-04-15T17:13:37.198720Z",
+     "iopub.status.idle": "2026-04-15T17:13:37.264260Z",
+     "shell.execute_reply": "2026-04-15T17:13:37.263559Z"
     }
    },
    "outputs": [
@@ -6515,7 +6497,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1530110</th>\n",
-       "      <td>0.2</td>\n",
+       "      <td>0.20</td>\n",
        "      <td>mg/l as P</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.2 milligram / liter</td>\n",
@@ -6555,7 +6537,7 @@
        "70783                0.002                          mg/L     NaN   \n",
        "...                    ...                           ...     ...   \n",
        "1530107               0.35                     mg/l as P     NaN   \n",
-       "1530110                0.2                     mg/l as P     NaN   \n",
+       "1530110               0.20                     mg/l as P     NaN   \n",
        "1530115               0.22                     mg/l as P     NaN   \n",
        "1530138               0.18                     mg/l as P     NaN   \n",
        "1530143               0.33                     mg/l as P     NaN   \n",
@@ -6591,10 +6573,10 @@
    "execution_count": 66,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:20.096089Z",
-     "iopub.status.busy": "2026-04-05T04:41:20.095889Z",
-     "iopub.status.idle": "2026-04-05T04:41:20.164401Z",
-     "shell.execute_reply": "2026-04-05T04:41:20.163677Z"
+     "iopub.execute_input": "2026-04-15T17:13:37.266376Z",
+     "iopub.status.busy": "2026-04-15T17:13:37.266164Z",
+     "iopub.status.idle": "2026-04-15T17:13:37.330514Z",
+     "shell.execute_reply": "2026-04-15T17:13:37.329878Z"
     }
    },
    "outputs": [
@@ -6670,35 +6652,35 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1525288</th>\n",
-       "      <td>420.0</td>\n",
+       "      <td>420</td>\n",
        "      <td>mg/kg as P</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1525628</th>\n",
-       "      <td>0.38</td>\n",
+       "      <td>0.380</td>\n",
        "      <td>%</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1525637</th>\n",
-       "      <td>330.0</td>\n",
+       "      <td>330</td>\n",
        "      <td>mg/kg as P</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1533251</th>\n",
-       "      <td>460.0</td>\n",
+       "      <td>460</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1533253</th>\n",
-       "      <td>5400.0</td>\n",
+       "      <td>5400</td>\n",
        "      <td>mg/kg</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -6716,11 +6698,11 @@
        "285845          0.16950375                          mg/L     NaN   \n",
        "295477          0.03524375                          mg/L     NaN   \n",
        "...                    ...                           ...     ...   \n",
-       "1525288              420.0                    mg/kg as P     NaN   \n",
-       "1525628               0.38                             %     NaN   \n",
-       "1525637              330.0                    mg/kg as P     NaN   \n",
-       "1533251              460.0                         mg/kg     NaN   \n",
-       "1533253             5400.0                         mg/kg     NaN   \n",
+       "1525288                420                    mg/kg as P     NaN   \n",
+       "1525628              0.380                             %     NaN   \n",
+       "1525637                330                    mg/kg as P     NaN   \n",
+       "1533251                460                         mg/kg     NaN   \n",
+       "1533253               5400                         mg/kg     NaN   \n",
        "\n",
        "        TDP_Phosphorus  \n",
        "262349             NaN  \n",
@@ -6774,10 +6756,10 @@
    "execution_count": 67,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:20.166718Z",
-     "iopub.status.busy": "2026-04-05T04:41:20.166529Z",
-     "iopub.status.idle": "2026-04-05T04:41:33.180771Z",
-     "shell.execute_reply": "2026-04-05T04:41:33.180055Z"
+     "iopub.execute_input": "2026-04-15T17:13:37.332729Z",
+     "iopub.status.busy": "2026-04-15T17:13:37.332525Z",
+     "iopub.status.idle": "2026-04-15T17:13:48.804996Z",
+     "shell.execute_reply": "2026-04-15T17:13:48.804406Z"
     }
    },
    "outputs": [
@@ -6801,14 +6783,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
@@ -6817,7 +6791,15 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(300.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(300.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(160.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(2.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -6863,10 +6845,10 @@
    "execution_count": 68,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:33.182849Z",
-     "iopub.status.busy": "2026-04-05T04:41:33.182660Z",
-     "iopub.status.idle": "2026-04-05T04:41:33.311399Z",
-     "shell.execute_reply": "2026-04-05T04:41:33.310761Z"
+     "iopub.execute_input": "2026-04-15T17:13:48.806975Z",
+     "iopub.status.busy": "2026-04-15T17:13:48.806790Z",
+     "iopub.status.idle": "2026-04-15T17:13:48.933316Z",
+     "shell.execute_reply": "2026-04-15T17:13:48.932694Z"
     }
    },
    "outputs": [
@@ -6942,35 +6924,35 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1532254</th>\n",
-       "      <td>100.0</td>\n",
+       "      <td>100</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>100.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1532293</th>\n",
-       "      <td>1100.0</td>\n",
+       "      <td>1100</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>1100.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1532381</th>\n",
-       "      <td>300.0</td>\n",
+       "      <td>300</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>300.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1532435</th>\n",
-       "      <td>160.0</td>\n",
+       "      <td>160</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>160.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1535978</th>\n",
-       "      <td>2.0</td>\n",
+       "      <td>2</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>2.0 Colony_Forming_Units / milliliter</td>\n",
@@ -6988,11 +6970,11 @@
        "72                     280                       #/100mL     NaN   \n",
        "109                     52                     cfu/100mL     NaN   \n",
        "...                    ...                           ...     ...   \n",
-       "1532254              100.0                     cfu/100ml     NaN   \n",
-       "1532293             1100.0                     cfu/100ml     NaN   \n",
-       "1532381              300.0                     cfu/100ml     NaN   \n",
-       "1532435              160.0                     cfu/100ml     NaN   \n",
-       "1535978                2.0                     cfu/100ml     NaN   \n",
+       "1532254                100                     cfu/100ml     NaN   \n",
+       "1532293               1100                     cfu/100ml     NaN   \n",
+       "1532381                300                     cfu/100ml     NaN   \n",
+       "1532435                160                     cfu/100ml     NaN   \n",
+       "1535978                  2                     cfu/100ml     NaN   \n",
        "\n",
        "                                   Fecal_Coliform  \n",
        "13                                            NaN  \n",
@@ -7032,10 +7014,10 @@
    "execution_count": 69,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:33.313416Z",
-     "iopub.status.busy": "2026-04-05T04:41:33.313193Z",
-     "iopub.status.idle": "2026-04-05T04:41:40.860399Z",
-     "shell.execute_reply": "2026-04-05T04:41:40.859704Z"
+     "iopub.execute_input": "2026-04-15T17:13:48.935449Z",
+     "iopub.status.busy": "2026-04-15T17:13:48.935246Z",
+     "iopub.status.idle": "2026-04-15T17:13:55.939792Z",
+     "shell.execute_reply": "2026-04-15T17:13:55.939148Z"
     }
    },
    "outputs": [
@@ -7053,11 +7035,11 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(110.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(110.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(32.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(20.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -7103,10 +7085,10 @@
    "execution_count": 70,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:40.862394Z",
-     "iopub.status.busy": "2026-04-05T04:41:40.862152Z",
-     "iopub.status.idle": "2026-04-05T04:41:40.980970Z",
-     "shell.execute_reply": "2026-04-05T04:41:40.980129Z"
+     "iopub.execute_input": "2026-04-15T17:13:55.941679Z",
+     "iopub.status.busy": "2026-04-15T17:13:55.941500Z",
+     "iopub.status.idle": "2026-04-15T17:13:56.058774Z",
+     "shell.execute_reply": "2026-04-15T17:13:56.058133Z"
     }
    },
    "outputs": [
@@ -7182,35 +7164,35 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1520462</th>\n",
-       "      <td>200.0</td>\n",
+       "      <td>200</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>200.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1520567</th>\n",
-       "      <td>4.0</td>\n",
+       "      <td>4</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>4.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1520604</th>\n",
-       "      <td>110.0</td>\n",
+       "      <td>110</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>110.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1520629</th>\n",
-       "      <td>32.0</td>\n",
+       "      <td>32</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>32.0 Colony_Forming_Units / milliliter</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1520634</th>\n",
-       "      <td>20.0</td>\n",
+       "      <td>20</td>\n",
        "      <td>cfu/100ml</td>\n",
        "      <td>NaN</td>\n",
        "      <td>20.0 Colony_Forming_Units / milliliter</td>\n",
@@ -7228,11 +7210,11 @@
        "220737               553.9                     MPN/100mL     NaN   \n",
        "221299                  87                     MPN/100mL     NaN   \n",
        "...                    ...                           ...     ...   \n",
-       "1520462              200.0                     cfu/100ml     NaN   \n",
-       "1520567                4.0                     cfu/100ml     NaN   \n",
-       "1520604              110.0                     cfu/100ml     NaN   \n",
-       "1520629               32.0                     cfu/100ml     NaN   \n",
-       "1520634               20.0                     cfu/100ml     NaN   \n",
+       "1520462                200                     cfu/100ml     NaN   \n",
+       "1520567                  4                     cfu/100ml     NaN   \n",
+       "1520604                110                     cfu/100ml     NaN   \n",
+       "1520629                 32                     cfu/100ml     NaN   \n",
+       "1520634                 20                     cfu/100ml     NaN   \n",
        "\n",
        "                                          E_coli  \n",
        "218670                                       NaN  \n",
@@ -7293,10 +7275,10 @@
    "execution_count": 71,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:40.983278Z",
-     "iopub.status.busy": "2026-04-05T04:41:40.983060Z",
-     "iopub.status.idle": "2026-04-05T04:41:40.986252Z",
-     "shell.execute_reply": "2026-04-05T04:41:40.985553Z"
+     "iopub.execute_input": "2026-04-15T17:13:56.061086Z",
+     "iopub.status.busy": "2026-04-15T17:13:56.060884Z",
+     "iopub.status.idle": "2026-04-15T17:13:56.063652Z",
+     "shell.execute_reply": "2026-04-15T17:13:56.063148Z"
     }
    },
    "outputs": [],
@@ -7309,10 +7291,10 @@
    "execution_count": 72,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:40.988087Z",
-     "iopub.status.busy": "2026-04-05T04:41:40.987886Z",
-     "iopub.status.idle": "2026-04-05T04:41:41.120509Z",
-     "shell.execute_reply": "2026-04-05T04:41:41.119730Z"
+     "iopub.execute_input": "2026-04-15T17:13:56.065363Z",
+     "iopub.status.busy": "2026-04-15T17:13:56.065188Z",
+     "iopub.status.idle": "2026-04-15T17:13:56.205374Z",
+     "shell.execute_reply": "2026-04-15T17:13:56.204761Z"
     }
    },
    "outputs": [
@@ -7339,10 +7321,10 @@
    "execution_count": 73,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:41.122724Z",
-     "iopub.status.busy": "2026-04-05T04:41:41.122517Z",
-     "iopub.status.idle": "2026-04-05T04:41:41.138368Z",
-     "shell.execute_reply": "2026-04-05T04:41:41.137709Z"
+     "iopub.execute_input": "2026-04-15T17:13:56.207289Z",
+     "iopub.status.busy": "2026-04-15T17:13:56.207075Z",
+     "iopub.status.idle": "2026-04-15T17:13:56.222332Z",
+     "shell.execute_reply": "2026-04-15T17:13:56.221711Z"
     }
    },
    "outputs": [
@@ -7374,10 +7356,10 @@
    "execution_count": 74,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:41.140488Z",
-     "iopub.status.busy": "2026-04-05T04:41:41.140254Z",
-     "iopub.status.idle": "2026-04-05T04:41:41.143396Z",
-     "shell.execute_reply": "2026-04-05T04:41:41.142675Z"
+     "iopub.execute_input": "2026-04-15T17:13:56.224280Z",
+     "iopub.status.busy": "2026-04-15T17:13:56.224064Z",
+     "iopub.status.idle": "2026-04-15T17:13:56.226582Z",
+     "shell.execute_reply": "2026-04-15T17:13:56.226086Z"
     }
    },
    "outputs": [],
@@ -7391,10 +7373,10 @@
    "execution_count": 75,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:41:41.145210Z",
-     "iopub.status.busy": "2026-04-05T04:41:41.145035Z",
-     "iopub.status.idle": "2026-04-05T04:42:18.806024Z",
-     "shell.execute_reply": "2026-04-05T04:42:18.805249Z"
+     "iopub.execute_input": "2026-04-15T17:13:56.228261Z",
+     "iopub.status.busy": "2026-04-15T17:13:56.228050Z",
+     "iopub.status.idle": "2026-04-15T17:14:32.116139Z",
+     "shell.execute_reply": "2026-04-15T17:14:32.115490Z"
     }
    },
    "outputs": [
@@ -7505,10 +7487,10 @@
    "execution_count": 76,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:42:18.808155Z",
-     "iopub.status.busy": "2026-04-05T04:42:18.807970Z",
-     "iopub.status.idle": "2026-04-05T04:44:44.153264Z",
-     "shell.execute_reply": "2026-04-05T04:44:44.152594Z"
+     "iopub.execute_input": "2026-04-15T17:14:32.118028Z",
+     "iopub.status.busy": "2026-04-15T17:14:32.117848Z",
+     "iopub.status.idle": "2026-04-15T17:16:12.607847Z",
+     "shell.execute_reply": "2026-04-15T17:16:12.607273Z"
     }
    },
    "outputs": [
@@ -7534,10 +7516,10 @@
    "execution_count": 77,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:44:44.155655Z",
-     "iopub.status.busy": "2026-04-05T04:44:44.155442Z",
-     "iopub.status.idle": "2026-04-05T04:45:08.494121Z",
-     "shell.execute_reply": "2026-04-05T04:45:08.493374Z"
+     "iopub.execute_input": "2026-04-15T17:16:12.610183Z",
+     "iopub.status.busy": "2026-04-15T17:16:12.609942Z",
+     "iopub.status.idle": "2026-04-15T17:16:34.174456Z",
+     "shell.execute_reply": "2026-04-15T17:16:34.173734Z"
     }
    },
    "outputs": [
@@ -7630,7 +7612,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>542722</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7641,7 +7623,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>563840</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7784,7 +7766,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1268175</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7795,7 +7777,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1269509</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7806,7 +7788,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1269518</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7817,7 +7799,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1269520</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7828,7 +7810,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1269521</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7839,7 +7821,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1269525</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7850,7 +7832,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1269526</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7861,7 +7843,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1270120</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7872,7 +7854,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1286749</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7883,7 +7865,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1286760</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7894,7 +7876,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1287970</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7905,7 +7887,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288040</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7916,7 +7898,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288099</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7927,7 +7909,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288248</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7938,7 +7920,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288590</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7949,7 +7931,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288599</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7960,7 +7942,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288600</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7971,7 +7953,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288635</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7982,7 +7964,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288640</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -7993,7 +7975,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288642</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -8004,7 +7986,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288659</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -8015,7 +7997,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288668</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -8026,7 +8008,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1288672</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -8037,7 +8019,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1294193</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -8048,7 +8030,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1312645</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ppth</td>\n",
        "      <td>NaN</td>\n",
        "      <td>0.0 Practical_Salinity_Units</td>\n",
@@ -8079,8 +8061,8 @@
        "46162                  0.0                          ppth     NaN   \n",
        "46163                  0.0                          ppth     NaN   \n",
        "508042                   0                          ppth     NaN   \n",
-       "542722                 0.0                          ppth     NaN   \n",
-       "563840                 0.0                          ppth     NaN   \n",
+       "542722                   0                          ppth     NaN   \n",
+       "563840                   0                          ppth     NaN   \n",
        "795838               -0.02                          ppth     NaN   \n",
        "1094967                  0                          ppth     NaN   \n",
        "1097798                  0                          ppth     NaN   \n",
@@ -8093,31 +8075,31 @@
        "1106151                  0                          ppth     NaN   \n",
        "1108237               0.00                          ppth     NaN   \n",
        "1139339              -0.01                          ppth     NaN   \n",
-       "1268175                0.0                          ppth     NaN   \n",
-       "1269509                0.0                          ppth     NaN   \n",
-       "1269518                0.0                          ppth     NaN   \n",
-       "1269520                0.0                          ppth     NaN   \n",
-       "1269521                0.0                          ppth     NaN   \n",
-       "1269525                0.0                          ppth     NaN   \n",
-       "1269526                0.0                          ppth     NaN   \n",
-       "1270120                0.0                          ppth     NaN   \n",
-       "1286749                0.0                          ppth     NaN   \n",
-       "1286760                0.0                          ppth     NaN   \n",
-       "1287970                0.0                          ppth     NaN   \n",
-       "1288040                0.0                          ppth     NaN   \n",
-       "1288099                0.0                          ppth     NaN   \n",
-       "1288248                0.0                          ppth     NaN   \n",
-       "1288590                0.0                          ppth     NaN   \n",
-       "1288599                0.0                          ppth     NaN   \n",
-       "1288600                0.0                          ppth     NaN   \n",
-       "1288635                0.0                          ppth     NaN   \n",
-       "1288640                0.0                          ppth     NaN   \n",
-       "1288642                0.0                          ppth     NaN   \n",
-       "1288659                0.0                          ppth     NaN   \n",
-       "1288668                0.0                          ppth     NaN   \n",
-       "1288672                0.0                          ppth     NaN   \n",
-       "1294193                0.0                          ppth     NaN   \n",
-       "1312645                0.0                          ppth     NaN   \n",
+       "1268175                  0                          ppth     NaN   \n",
+       "1269509                  0                          ppth     NaN   \n",
+       "1269518                  0                          ppth     NaN   \n",
+       "1269520                  0                          ppth     NaN   \n",
+       "1269521                  0                          ppth     NaN   \n",
+       "1269525                  0                          ppth     NaN   \n",
+       "1269526                  0                          ppth     NaN   \n",
+       "1270120                  0                          ppth     NaN   \n",
+       "1286749                  0                          ppth     NaN   \n",
+       "1286760                  0                          ppth     NaN   \n",
+       "1287970                  0                          ppth     NaN   \n",
+       "1288040                  0                          ppth     NaN   \n",
+       "1288099                  0                          ppth     NaN   \n",
+       "1288248                  0                          ppth     NaN   \n",
+       "1288590                  0                          ppth     NaN   \n",
+       "1288599                  0                          ppth     NaN   \n",
+       "1288600                  0                          ppth     NaN   \n",
+       "1288635                  0                          ppth     NaN   \n",
+       "1288640                  0                          ppth     NaN   \n",
+       "1288642                  0                          ppth     NaN   \n",
+       "1288659                  0                          ppth     NaN   \n",
+       "1288668                  0                          ppth     NaN   \n",
+       "1288672                  0                          ppth     NaN   \n",
+       "1294193                  0                          ppth     NaN   \n",
+       "1312645                  0                          ppth     NaN   \n",
        "1498498                  0                           PSS     NaN   \n",
        "\n",
        "                               Salinity ResultDetectionConditionText  \\\n",
@@ -8331,10 +8313,10 @@
    "execution_count": 78,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:08.496299Z",
-     "iopub.status.busy": "2026-04-05T04:45:08.496072Z",
-     "iopub.status.idle": "2026-04-05T04:45:08.526977Z",
-     "shell.execute_reply": "2026-04-05T04:45:08.526212Z"
+     "iopub.execute_input": "2026-04-15T17:16:34.176422Z",
+     "iopub.status.busy": "2026-04-15T17:16:34.176226Z",
+     "iopub.status.idle": "2026-04-15T17:16:34.207473Z",
+     "shell.execute_reply": "2026-04-15T17:16:34.206927Z"
     }
    },
    "outputs": [
@@ -8378,10 +8360,10 @@
    "execution_count": 79,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:08.528979Z",
-     "iopub.status.busy": "2026-04-05T04:45:08.528782Z",
-     "iopub.status.idle": "2026-04-05T04:45:09.433956Z",
-     "shell.execute_reply": "2026-04-05T04:45:09.433166Z"
+     "iopub.execute_input": "2026-04-15T17:16:34.209353Z",
+     "iopub.status.busy": "2026-04-15T17:16:34.209167Z",
+     "iopub.status.idle": "2026-04-15T17:16:34.968263Z",
+     "shell.execute_reply": "2026-04-15T17:16:34.967649Z"
     }
    },
    "outputs": [
@@ -8551,10 +8533,10 @@
    "execution_count": 80,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:09.436097Z",
-     "iopub.status.busy": "2026-04-05T04:45:09.435891Z",
-     "iopub.status.idle": "2026-04-05T04:45:09.521687Z",
-     "shell.execute_reply": "2026-04-05T04:45:09.520947Z"
+     "iopub.execute_input": "2026-04-15T17:16:34.970384Z",
+     "iopub.status.busy": "2026-04-15T17:16:34.970179Z",
+     "iopub.status.idle": "2026-04-15T17:16:35.054693Z",
+     "shell.execute_reply": "2026-04-15T17:16:35.054055Z"
     }
    },
    "outputs": [
@@ -8606,10 +8588,10 @@
    "execution_count": 81,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:09.523942Z",
-     "iopub.status.busy": "2026-04-05T04:45:09.523729Z",
-     "iopub.status.idle": "2026-04-05T04:45:09.548624Z",
-     "shell.execute_reply": "2026-04-05T04:45:09.547898Z"
+     "iopub.execute_input": "2026-04-15T17:16:35.056784Z",
+     "iopub.status.busy": "2026-04-15T17:16:35.056586Z",
+     "iopub.status.idle": "2026-04-15T17:16:35.079660Z",
+     "shell.execute_reply": "2026-04-15T17:16:35.079036Z"
     }
    },
    "outputs": [
@@ -8757,10 +8739,10 @@
    "execution_count": 82,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:09.550731Z",
-     "iopub.status.busy": "2026-04-05T04:45:09.550526Z",
-     "iopub.status.idle": "2026-04-05T04:45:17.163129Z",
-     "shell.execute_reply": "2026-04-05T04:45:17.162378Z"
+     "iopub.execute_input": "2026-04-15T17:16:35.081458Z",
+     "iopub.status.busy": "2026-04-15T17:16:35.081273Z",
+     "iopub.status.idle": "2026-04-15T17:16:42.392531Z",
+     "shell.execute_reply": "2026-04-15T17:16:42.391895Z"
     }
    },
    "outputs": [
@@ -8904,10 +8886,10 @@
    "execution_count": 83,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:17.165554Z",
-     "iopub.status.busy": "2026-04-05T04:45:17.165232Z",
-     "iopub.status.idle": "2026-04-05T04:45:18.000841Z",
-     "shell.execute_reply": "2026-04-05T04:45:18.000223Z"
+     "iopub.execute_input": "2026-04-15T17:16:42.394581Z",
+     "iopub.status.busy": "2026-04-15T17:16:42.394396Z",
+     "iopub.status.idle": "2026-04-15T17:16:43.148959Z",
+     "shell.execute_reply": "2026-04-15T17:16:43.148334Z"
     }
    },
    "outputs": [
@@ -8952,10 +8934,10 @@
    "execution_count": 84,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:18.002883Z",
-     "iopub.status.busy": "2026-04-05T04:45:18.002673Z",
-     "iopub.status.idle": "2026-04-05T04:45:34.430158Z",
-     "shell.execute_reply": "2026-04-05T04:45:34.429481Z"
+     "iopub.execute_input": "2026-04-15T17:16:43.151004Z",
+     "iopub.status.busy": "2026-04-15T17:16:43.150806Z",
+     "iopub.status.idle": "2026-04-15T17:16:57.757088Z",
+     "shell.execute_reply": "2026-04-15T17:16:57.756458Z"
     }
    },
    "outputs": [
@@ -8991,16 +8973,16 @@
        "      <th>DataLoggerLine</th>\n",
        "      <th>ResultDetectionConditionText</th>\n",
        "      <th>...</th>\n",
+       "      <th>QA_TP_Phosphorus</th>\n",
+       "      <th>QA_TDP_Phosphorus</th>\n",
+       "      <th>QA_Other_Phosphorus</th>\n",
        "      <th>QA_E_coli</th>\n",
+       "      <th>QA_Secchi</th>\n",
        "      <th>QA_Fecal_Coliform</th>\n",
-       "      <th>QA_DO</th>\n",
-       "      <th>QA_Carbon</th>\n",
-       "      <th>QA_Nitrogen</th>\n",
        "      <th>QA_Chlorophyll</th>\n",
-       "      <th>QA_pH</th>\n",
-       "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Temperature</th>\n",
-       "      <th>QA_Conductivity</th>\n",
+       "      <th>QA_Salinity</th>\n",
+       "      <th>QA_Nitrogen</th>\n",
+       "      <th>QA_DO</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -9326,44 +9308,44 @@
        "1541621                   21FLBSG-13  STORET-100013998412.0000000000   \n",
        "1541622                   21FLBSG-13  STORET-100013857818.0000000000   \n",
        "\n",
-       "         DataLoggerLine ResultDetectionConditionText  ... QA_E_coli  \\\n",
-       "878300              NaN                          NaN  ...       NaN   \n",
-       "621908              NaN                          NaN  ...       NaN   \n",
-       "624663              NaN                          NaN  ...       NaN   \n",
-       "627685              NaN                          NaN  ...       NaN   \n",
-       "625595              NaN                          NaN  ...       NaN   \n",
-       "...                 ...                          ...  ...       ...   \n",
-       "1541618             NaN                          NaN  ...       NaN   \n",
-       "1541619             NaN                          NaN  ...       NaN   \n",
-       "1541620             NaN                          NaN  ...       NaN   \n",
-       "1541621             NaN                          NaN  ...       NaN   \n",
-       "1541622             NaN                          NaN  ...       NaN   \n",
+       "         DataLoggerLine ResultDetectionConditionText  ... QA_TP_Phosphorus  \\\n",
+       "878300              NaN                          NaN  ...              NaN   \n",
+       "621908              NaN                          NaN  ...              NaN   \n",
+       "624663              NaN                          NaN  ...              NaN   \n",
+       "627685              NaN                          NaN  ...              NaN   \n",
+       "625595              NaN                          NaN  ...              NaN   \n",
+       "...                 ...                          ...  ...              ...   \n",
+       "1541618             NaN                          NaN  ...              NaN   \n",
+       "1541619             NaN                          NaN  ...              NaN   \n",
+       "1541620             NaN                          NaN  ...              NaN   \n",
+       "1541621             NaN                          NaN  ...              NaN   \n",
+       "1541622             NaN                          NaN  ...              NaN   \n",
        "\n",
-       "        QA_Fecal_Coliform QA_DO QA_Carbon QA_Nitrogen QA_Chlorophyll QA_pH  \\\n",
-       "878300                NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "621908                NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "624663                NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "627685                NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "625595                NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "...                   ...   ...       ...         ...            ...   ...   \n",
-       "1541618               NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "1541619               NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "1541620               NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "1541621               NaN   NaN       NaN         NaN            NaN   NaN   \n",
-       "1541622               NaN   NaN       NaN         NaN            NaN   NaN   \n",
+       "        QA_TDP_Phosphorus QA_Other_Phosphorus QA_E_coli QA_Secchi  \\\n",
+       "878300                NaN                 NaN       NaN       NaN   \n",
+       "621908                NaN                 NaN       NaN       NaN   \n",
+       "624663                NaN                 NaN       NaN       NaN   \n",
+       "627685                NaN                 NaN       NaN       NaN   \n",
+       "625595                NaN                 NaN       NaN       NaN   \n",
+       "...                   ...                 ...       ...       ...   \n",
+       "1541618               NaN                 NaN       NaN       NaN   \n",
+       "1541619               NaN                 NaN       NaN       NaN   \n",
+       "1541620               NaN                 NaN       NaN       NaN   \n",
+       "1541621               NaN                 NaN       NaN       NaN   \n",
+       "1541622               NaN                 NaN       NaN       NaN   \n",
        "\n",
-       "        QA_Turbidity QA_Temperature QA_Conductivity  \n",
-       "878300           NaN            NaN             NaN  \n",
-       "621908           NaN            NaN             NaN  \n",
-       "624663           NaN            NaN             NaN  \n",
-       "627685           NaN            NaN             NaN  \n",
-       "625595           NaN            NaN             NaN  \n",
-       "...              ...            ...             ...  \n",
-       "1541618          NaN            NaN             NaN  \n",
-       "1541619          NaN            NaN             NaN  \n",
-       "1541620          NaN            NaN             NaN  \n",
-       "1541621          NaN            NaN             NaN  \n",
-       "1541622          NaN            NaN             NaN  \n",
+       "        QA_Fecal_Coliform QA_Chlorophyll QA_Salinity QA_Nitrogen QA_DO  \n",
+       "878300                NaN            NaN         NaN         NaN   NaN  \n",
+       "621908                NaN            NaN         NaN         NaN   NaN  \n",
+       "624663                NaN            NaN         NaN         NaN   NaN  \n",
+       "627685                NaN            NaN         NaN         NaN   NaN  \n",
+       "625595                NaN            NaN         NaN         NaN   NaN  \n",
+       "...                   ...            ...         ...         ...   ...  \n",
+       "1541618               NaN            NaN         NaN         NaN   NaN  \n",
+       "1541619               NaN            NaN         NaN         NaN   NaN  \n",
+       "1541620               NaN            NaN         NaN         NaN   NaN  \n",
+       "1541621               NaN            NaN         NaN         NaN   NaN  \n",
+       "1541622               NaN            NaN         NaN         NaN   NaN  \n",
        "\n",
        "[1469564 rows x 117 columns]"
       ]
@@ -9384,10 +9366,10 @@
    "execution_count": 85,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:34.432211Z",
-     "iopub.status.busy": "2026-04-05T04:45:34.432002Z",
-     "iopub.status.idle": "2026-04-05T04:45:34.435399Z",
-     "shell.execute_reply": "2026-04-05T04:45:34.434792Z"
+     "iopub.execute_input": "2026-04-15T17:16:57.759158Z",
+     "iopub.status.busy": "2026-04-15T17:16:57.758935Z",
+     "iopub.status.idle": "2026-04-15T17:16:57.762210Z",
+     "shell.execute_reply": "2026-04-15T17:16:57.761658Z"
     }
    },
    "outputs": [
@@ -9409,10 +9391,10 @@
    "execution_count": 86,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:34.437196Z",
-     "iopub.status.busy": "2026-04-05T04:45:34.437023Z",
-     "iopub.status.idle": "2026-04-05T04:45:34.440404Z",
-     "shell.execute_reply": "2026-04-05T04:45:34.439715Z"
+     "iopub.execute_input": "2026-04-15T17:16:57.763982Z",
+     "iopub.status.busy": "2026-04-15T17:16:57.763797Z",
+     "iopub.status.idle": "2026-04-15T17:16:57.766734Z",
+     "shell.execute_reply": "2026-04-15T17:16:57.766211Z"
     }
    },
    "outputs": [
@@ -9434,10 +9416,10 @@
    "execution_count": 87,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:34.442143Z",
-     "iopub.status.busy": "2026-04-05T04:45:34.441953Z",
-     "iopub.status.idle": "2026-04-05T04:45:34.511164Z",
-     "shell.execute_reply": "2026-04-05T04:45:34.510465Z"
+     "iopub.execute_input": "2026-04-15T17:16:57.768429Z",
+     "iopub.status.busy": "2026-04-15T17:16:57.768253Z",
+     "iopub.status.idle": "2026-04-15T17:16:57.836167Z",
+     "shell.execute_reply": "2026-04-15T17:16:57.835502Z"
     }
    },
    "outputs": [
@@ -9502,10 +9484,10 @@
    "execution_count": 88,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:34.513189Z",
-     "iopub.status.busy": "2026-04-05T04:45:34.512991Z",
-     "iopub.status.idle": "2026-04-05T04:45:36.541822Z",
-     "shell.execute_reply": "2026-04-05T04:45:36.540997Z"
+     "iopub.execute_input": "2026-04-15T17:16:57.838169Z",
+     "iopub.status.busy": "2026-04-15T17:16:57.837936Z",
+     "iopub.status.idle": "2026-04-15T17:16:59.722741Z",
+     "shell.execute_reply": "2026-04-15T17:16:59.722150Z"
     }
    },
    "outputs": [],
@@ -9519,10 +9501,10 @@
    "execution_count": 89,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:36.544286Z",
-     "iopub.status.busy": "2026-04-05T04:45:36.544048Z",
-     "iopub.status.idle": "2026-04-05T04:45:36.548760Z",
-     "shell.execute_reply": "2026-04-05T04:45:36.548059Z"
+     "iopub.execute_input": "2026-04-15T17:16:59.725143Z",
+     "iopub.status.busy": "2026-04-15T17:16:59.724903Z",
+     "iopub.status.idle": "2026-04-15T17:16:59.729294Z",
+     "shell.execute_reply": "2026-04-15T17:16:59.728742Z"
     }
    },
    "outputs": [
@@ -9538,11 +9520,11 @@
        "       'E_coli', 'DetectionQuantitationLimitTypeName',\n",
        "       'DetectionQuantitationLimitMeasure/MeasureValue',\n",
        "       'DetectionQuantitationLimitMeasure/MeasureUnitCode',\n",
-       "       'Activity_datetime', 'Depth', 'QA_Salinity', 'QA_Secchi',\n",
-       "       'QA_TP_Phosphorus', 'QA_TDP_Phosphorus', 'QA_Other_Phosphorus',\n",
-       "       'QA_E_coli', 'QA_Fecal_Coliform', 'QA_DO', 'QA_Carbon', 'QA_Nitrogen',\n",
-       "       'QA_Chlorophyll', 'QA_pH', 'QA_Turbidity', 'QA_Temperature',\n",
-       "       'QA_Conductivity'],\n",
+       "       'Activity_datetime', 'Depth', 'QA_Turbidity', 'QA_Conductivity',\n",
+       "       'QA_Temperature', 'QA_Carbon', 'QA_pH', 'QA_TP_Phosphorus',\n",
+       "       'QA_TDP_Phosphorus', 'QA_Other_Phosphorus', 'QA_E_coli', 'QA_Secchi',\n",
+       "       'QA_Fecal_Coliform', 'QA_Chlorophyll', 'QA_Salinity', 'QA_Nitrogen',\n",
+       "       'QA_DO'],\n",
        "      dtype='object')"
       ]
      },
@@ -9561,10 +9543,10 @@
    "execution_count": 90,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:36.550606Z",
-     "iopub.status.busy": "2026-04-05T04:45:36.550398Z",
-     "iopub.status.idle": "2026-04-05T04:45:36.565061Z",
-     "shell.execute_reply": "2026-04-05T04:45:36.564365Z"
+     "iopub.execute_input": "2026-04-15T17:16:59.730973Z",
+     "iopub.status.busy": "2026-04-15T17:16:59.730808Z",
+     "iopub.status.idle": "2026-04-15T17:16:59.743760Z",
+     "shell.execute_reply": "2026-04-15T17:16:59.743099Z"
     }
    },
    "outputs": [
@@ -9600,16 +9582,16 @@
        "      <th>pH</th>\n",
        "      <th>Salinity</th>\n",
        "      <th>...</th>\n",
+       "      <th>QA_TP_Phosphorus</th>\n",
+       "      <th>QA_TDP_Phosphorus</th>\n",
+       "      <th>QA_Other_Phosphorus</th>\n",
        "      <th>QA_E_coli</th>\n",
+       "      <th>QA_Secchi</th>\n",
        "      <th>QA_Fecal_Coliform</th>\n",
-       "      <th>QA_DO</th>\n",
-       "      <th>QA_Carbon</th>\n",
-       "      <th>QA_Nitrogen</th>\n",
        "      <th>QA_Chlorophyll</th>\n",
-       "      <th>QA_pH</th>\n",
-       "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Temperature</th>\n",
-       "      <th>QA_Conductivity</th>\n",
+       "      <th>QA_Salinity</th>\n",
+       "      <th>QA_Nitrogen</th>\n",
+       "      <th>QA_DO</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -9760,19 +9742,26 @@
        "627685       STORET    NaN         NaN  NaN  NaN   0.379 dimensionless  ...   \n",
        "625595       STORET    NaN         NaN  NaN  NaN   0.379 dimensionless  ...   \n",
        "\n",
-       "       QA_E_coli QA_Fecal_Coliform QA_DO QA_Carbon QA_Nitrogen QA_Chlorophyll  \\\n",
-       "878300       NaN               NaN   NaN       NaN         NaN            NaN   \n",
-       "621908       NaN               NaN   NaN       NaN         NaN            NaN   \n",
-       "624663       NaN               NaN   NaN       NaN         NaN            NaN   \n",
-       "627685       NaN               NaN   NaN       NaN         NaN            NaN   \n",
-       "625595       NaN               NaN   NaN       NaN         NaN            NaN   \n",
+       "       QA_TP_Phosphorus QA_TDP_Phosphorus QA_Other_Phosphorus QA_E_coli  \\\n",
+       "878300              NaN               NaN                 NaN       NaN   \n",
+       "621908              NaN               NaN                 NaN       NaN   \n",
+       "624663              NaN               NaN                 NaN       NaN   \n",
+       "627685              NaN               NaN                 NaN       NaN   \n",
+       "625595              NaN               NaN                 NaN       NaN   \n",
        "\n",
-       "       QA_pH QA_Turbidity QA_Temperature QA_Conductivity  \n",
-       "878300   NaN          NaN            NaN             NaN  \n",
-       "621908   NaN          NaN            NaN             NaN  \n",
-       "624663   NaN          NaN            NaN             NaN  \n",
-       "627685   NaN          NaN            NaN             NaN  \n",
-       "625595   NaN          NaN            NaN             NaN  \n",
+       "       QA_Secchi QA_Fecal_Coliform QA_Chlorophyll QA_Salinity QA_Nitrogen  \\\n",
+       "878300       NaN               NaN            NaN         NaN         NaN   \n",
+       "621908       NaN               NaN            NaN         NaN         NaN   \n",
+       "624663       NaN               NaN            NaN         NaN         NaN   \n",
+       "627685       NaN               NaN            NaN         NaN         NaN   \n",
+       "625595       NaN               NaN            NaN         NaN         NaN   \n",
+       "\n",
+       "       QA_DO  \n",
+       "878300   NaN  \n",
+       "621908   NaN  \n",
+       "624663   NaN  \n",
+       "627685   NaN  \n",
+       "625595   NaN  \n",
        "\n",
        "[5 rows x 44 columns]"
       ]
@@ -9792,10 +9781,10 @@
    "execution_count": 91,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:36.566846Z",
-     "iopub.status.busy": "2026-04-05T04:45:36.566646Z",
-     "iopub.status.idle": "2026-04-05T04:45:37.984089Z",
-     "shell.execute_reply": "2026-04-05T04:45:37.983157Z"
+     "iopub.execute_input": "2026-04-15T17:16:59.745497Z",
+     "iopub.status.busy": "2026-04-15T17:16:59.745321Z",
+     "iopub.status.idle": "2026-04-15T17:17:01.171486Z",
+     "shell.execute_reply": "2026-04-15T17:17:01.170825Z"
     }
    },
    "outputs": [
@@ -9803,16 +9792,16 @@
      "data": {
       "text/plain": [
        "['Sediment',\n",
-       " 'QA_Salinity',\n",
+       " 'QA_Turbidity',\n",
+       " 'QA_Conductivity',\n",
+       " 'QA_Temperature',\n",
+       " 'QA_Carbon',\n",
        " 'QA_TDP_Phosphorus',\n",
        " 'QA_Other_Phosphorus',\n",
        " 'QA_E_coli',\n",
-       " 'QA_DO',\n",
-       " 'QA_Carbon',\n",
+       " 'QA_Salinity',\n",
        " 'QA_Nitrogen',\n",
-       " 'QA_Turbidity',\n",
-       " 'QA_Temperature',\n",
-       " 'QA_Conductivity']"
+       " 'QA_DO']"
       ]
      },
      "execution_count": 91,
@@ -9832,10 +9821,10 @@
    "execution_count": 92,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:37.986682Z",
-     "iopub.status.busy": "2026-04-05T04:45:37.986380Z",
-     "iopub.status.idle": "2026-04-05T04:45:39.360573Z",
-     "shell.execute_reply": "2026-04-05T04:45:39.359832Z"
+     "iopub.execute_input": "2026-04-15T17:17:01.173486Z",
+     "iopub.status.busy": "2026-04-15T17:17:01.173287Z",
+     "iopub.status.idle": "2026-04-15T17:17:02.570790Z",
+     "shell.execute_reply": "2026-04-15T17:17:02.570123Z"
     }
    },
    "outputs": [

--- a/demos/Harmonize_Tampa_Simple.ipynb
+++ b/demos/Harmonize_Tampa_Simple.ipynb
@@ -58,10 +58,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:45.751403Z",
-     "iopub.status.busy": "2026-04-05T04:45:45.751187Z",
-     "iopub.status.idle": "2026-04-05T04:45:45.757737Z",
-     "shell.execute_reply": "2026-04-05T04:45:45.757043Z"
+     "iopub.execute_input": "2026-04-15T17:17:08.791461Z",
+     "iopub.status.busy": "2026-04-15T17:17:08.791277Z",
+     "iopub.status.idle": "2026-04-15T17:17:08.797136Z",
+     "shell.execute_reply": "2026-04-15T17:17:08.796686Z"
     },
     "hidden": true
    },
@@ -89,10 +89,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:45.759884Z",
-     "iopub.status.busy": "2026-04-05T04:45:45.759682Z",
-     "iopub.status.idle": "2026-04-05T04:45:46.379549Z",
-     "shell.execute_reply": "2026-04-05T04:45:46.378743Z"
+     "iopub.execute_input": "2026-04-15T17:17:08.798954Z",
+     "iopub.status.busy": "2026-04-15T17:17:08.798764Z",
+     "iopub.status.idle": "2026-04-15T17:17:09.380002Z",
+     "shell.execute_reply": "2026-04-15T17:17:09.379480Z"
     }
    },
    "outputs": [],
@@ -105,10 +105,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:46.382033Z",
-     "iopub.status.busy": "2026-04-05T04:45:46.381772Z",
-     "iopub.status.idle": "2026-04-05T04:45:46.384672Z",
-     "shell.execute_reply": "2026-04-05T04:45:46.384094Z"
+     "iopub.execute_input": "2026-04-15T17:17:09.382428Z",
+     "iopub.status.busy": "2026-04-15T17:17:09.382157Z",
+     "iopub.status.idle": "2026-04-15T17:17:09.384753Z",
+     "shell.execute_reply": "2026-04-15T17:17:09.384281Z"
     },
     "hidden": true
    },
@@ -124,10 +124,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:46.386576Z",
-     "iopub.status.busy": "2026-04-05T04:45:46.386398Z",
-     "iopub.status.idle": "2026-04-05T04:45:49.685162Z",
-     "shell.execute_reply": "2026-04-05T04:45:49.684455Z"
+     "iopub.execute_input": "2026-04-15T17:17:09.386491Z",
+     "iopub.status.busy": "2026-04-15T17:17:09.386304Z",
+     "iopub.status.idle": "2026-04-15T17:17:11.299261Z",
+     "shell.execute_reply": "2026-04-15T17:17:11.298640Z"
     }
    },
    "outputs": [
@@ -165,10 +165,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:49.701449Z",
-     "iopub.status.busy": "2026-04-05T04:45:49.701075Z",
-     "iopub.status.idle": "2026-04-05T04:45:49.705479Z",
-     "shell.execute_reply": "2026-04-05T04:45:49.704902Z"
+     "iopub.execute_input": "2026-04-15T17:17:11.316288Z",
+     "iopub.status.busy": "2026-04-15T17:17:11.315934Z",
+     "iopub.status.idle": "2026-04-15T17:17:11.320094Z",
+     "shell.execute_reply": "2026-04-15T17:17:11.319641Z"
     },
     "hidden": true
    },
@@ -216,10 +216,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:49.707375Z",
-     "iopub.status.busy": "2026-04-05T04:45:49.707171Z",
-     "iopub.status.idle": "2026-04-05T04:45:49.709834Z",
-     "shell.execute_reply": "2026-04-05T04:45:49.709289Z"
+     "iopub.execute_input": "2026-04-15T17:17:11.321893Z",
+     "iopub.status.busy": "2026-04-15T17:17:11.321723Z",
+     "iopub.status.idle": "2026-04-15T17:17:11.324078Z",
+     "shell.execute_reply": "2026-04-15T17:17:11.323601Z"
     }
    },
    "outputs": [],
@@ -232,23 +232,14 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:49.711573Z",
-     "iopub.status.busy": "2026-04-05T04:45:49.711374Z",
-     "iopub.status.idle": "2026-04-05T04:45:59.753838Z",
-     "shell.execute_reply": "2026-04-05T04:45:59.753125Z"
+     "iopub.execute_input": "2026-04-15T17:17:11.325768Z",
+     "iopub.status.busy": "2026-04-15T17:17:11.325598Z",
+     "iopub.status.idle": "2026-04-15T17:17:22.821363Z",
+     "shell.execute_reply": "2026-04-15T17:17:22.820769Z"
     },
     "hidden": true
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:153: DtypeWarning: Columns (9,10,13,15,17,19,22,23,28,31,33,36,38,58,60,61,62,64,65,70,71,73) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Query for results\n",
     "# Note: large quieries like this can take up a lot of RAM and may give a DtypeWarning,\n",
@@ -261,10 +252,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:45:59.756645Z",
-     "iopub.status.busy": "2026-04-05T04:45:59.756412Z",
-     "iopub.status.idle": "2026-04-05T04:46:00.249657Z",
-     "shell.execute_reply": "2026-04-05T04:46:00.248881Z"
+     "iopub.execute_input": "2026-04-15T17:17:22.824079Z",
+     "iopub.status.busy": "2026-04-15T17:17:22.823869Z",
+     "iopub.status.idle": "2026-04-15T17:17:23.272080Z",
+     "shell.execute_reply": "2026-04-15T17:17:23.271430Z"
     },
     "hidden": true
    },
@@ -755,10 +746,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:46:00.251877Z",
-     "iopub.status.busy": "2026-04-05T04:46:00.251674Z",
-     "iopub.status.idle": "2026-04-05T04:46:00.254924Z",
-     "shell.execute_reply": "2026-04-05T04:46:00.254399Z"
+     "iopub.execute_input": "2026-04-15T17:17:23.274250Z",
+     "iopub.status.busy": "2026-04-15T17:17:23.274033Z",
+     "iopub.status.idle": "2026-04-15T17:17:23.277338Z",
+     "shell.execute_reply": "2026-04-15T17:17:23.276837Z"
     }
    },
    "outputs": [],
@@ -773,10 +764,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:46:00.256816Z",
-     "iopub.status.busy": "2026-04-05T04:46:00.256633Z",
-     "iopub.status.idle": "2026-04-05T04:48:46.403903Z",
-     "shell.execute_reply": "2026-04-05T04:48:46.403197Z"
+     "iopub.execute_input": "2026-04-15T17:17:23.279022Z",
+     "iopub.status.busy": "2026-04-15T17:17:23.278850Z",
+     "iopub.status.idle": "2026-04-15T17:19:43.560213Z",
+     "shell.execute_reply": "2026-04-15T17:19:43.559544Z"
     },
     "hidden": true
    },
@@ -801,7 +792,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.00594, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.00594, 'milligram / liter')>\n",
       " <Quantity(0.00145, 'milligram / liter')>\n",
       " <Quantity(0.00277, 'milligram / liter')> ...\n",
       " <Quantity(0.00741, 'milligram / liter')>\n",
@@ -822,7 +813,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(626.0, 'microsiemens / centimeter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(626.0, 'microsiemens / centimeter')>\n",
       " <Quantity(688.0, 'microsiemens / centimeter')>\n",
       " <Quantity(606.0, 'microsiemens / centimeter')>\n",
       " <Quantity(606.0, 'microsiemens / centimeter')>\n",
@@ -848,7 +839,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.8, 'meter')> <Quantity(2.2, 'meter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.8, 'meter')> <Quantity(2.2, 'meter')>\n",
       " <Quantity(2.7, 'meter')> ... <Quantity(2.4, 'meter')>\n",
       " <Quantity(1.8, 'meter')> <Quantity(3.3, 'meter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -866,7 +857,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(9.32, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(9.32, 'milligram / liter')>\n",
       " <Quantity(8.08, 'milligram / liter')>\n",
       " <Quantity(4.9, 'milligram / liter')> ...\n",
       " <Quantity(8.2, 'milligram / liter')> <Quantity(7.9, 'milligram / liter')>\n",
@@ -888,11 +879,11 @@
      "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'MPN/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(110.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(110.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(32.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(20.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -918,6 +909,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
+      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'CFU/100mL' converted to NaN\n",
       "  warn(f\"WARNING: '{unit}' converted to NaN\")\n"
      ]
@@ -926,9 +925,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/convert.py:128: UserWarning: WARNING: 'cfu/100mL' converted to NaN\n",
-      "  warn(f\"WARNING: '{unit}' converted to NaN\")\n",
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(300.0, 'Colony_Forming_Units / milliliter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... <Quantity(300.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(160.0, 'Colony_Forming_Units / milliliter')>\n",
       " <Quantity(2.0, 'Colony_Forming_Units / milliliter')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -971,7 +968,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.39, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.39, 'milligram / liter')>\n",
       " <Quantity(0.4475, 'milligram / liter')>\n",
       " <Quantity(0.425, 'milligram / liter')>\n",
       " <Quantity(0.4625, 'milligram / liter')>\n",
@@ -1163,7 +1160,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.8, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(3.8, 'milligram / liter')>\n",
       " <Quantity(19.5, 'milligram / liter')>\n",
       " <Quantity(11.3, 'milligram / liter')> ...\n",
       " <Quantity(4.8, 'milligram / liter')>\n",
@@ -1184,7 +1181,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(0.049, 'milligram / liter')>\n",
       " <Quantity(0.004, 'milligram / liter')>\n",
       " <Quantity(0.049, 'milligram / liter')> ...\n",
       " <Quantity(0.04, 'milligram / liter')>\n",
@@ -1227,7 +1224,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:510: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:513: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[nan nan nan ... nan nan nan]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  self.df[c_mask] = basis.update_result_basis(\n"
      ]
     },
@@ -1235,7 +1232,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(40.0, 'Practical_Salinity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(40.0, 'Practical_Salinity_Units')>\n",
       " <Quantity(29.0, 'Practical_Salinity_Units')>\n",
       " <Quantity(26.04, 'Practical_Salinity_Units')> ...\n",
       " <Quantity(31.3, 'Practical_Salinity_Units')>\n",
@@ -1256,7 +1253,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(28.19, 'degree_Celsius')> <Quantity(29.52, 'degree_Celsius')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(28.19, 'degree_Celsius')> <Quantity(29.52, 'degree_Celsius')>\n",
       " <Quantity(21.0, 'degree_Celsius')> ... <Quantity(31.2, 'degree_Celsius')>\n",
       " <Quantity(14.1, 'degree_Celsius')> <Quantity(31.1, 'degree_Celsius')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1274,7 +1271,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.49, 'Nephelometric_Turbidity_Units')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(4.49, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(1.2, 'Nephelometric_Turbidity_Units')>\n",
       " <Quantity(2.9, 'Nephelometric_Turbidity_Units')> ...\n",
       " <Quantity(0.7, 'Nephelometric_Turbidity_Units')>\n",
@@ -1295,7 +1292,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:663: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.48, 'dimensionless')> <Quantity(8.18, 'dimensionless')>\n",
+      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/wq_data.py:666: FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error in a future version of pandas. Value '[<Quantity(7.48, 'dimensionless')> <Quantity(8.18, 'dimensionless')>\n",
       " <Quantity(7.81, 'dimensionless')> ... <Quantity(7.8, 'dimensionless')>\n",
       " <Quantity(7.7, 'dimensionless')> <Quantity(7.6, 'dimensionless')>]' has dtype incompatible with float64, please explicitly cast to a compatible dtype first.\n",
       "  df_out.loc[m_mask, self.out_col] = convert_unit_series(**params)\n"
@@ -1754,10 +1751,10 @@
    "execution_count": 11,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:48:46.406120Z",
-     "iopub.status.busy": "2026-04-05T04:48:46.405913Z",
-     "iopub.status.idle": "2026-04-05T04:48:46.964346Z",
-     "shell.execute_reply": "2026-04-05T04:48:46.963672Z"
+     "iopub.execute_input": "2026-04-15T17:19:43.562344Z",
+     "iopub.status.busy": "2026-04-15T17:19:43.562123Z",
+     "iopub.status.idle": "2026-04-15T17:19:44.048614Z",
+     "shell.execute_reply": "2026-04-15T17:19:44.048049Z"
     },
     "hidden": true
    },
@@ -1766,8 +1763,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/dataretrieval/wqp.py:210: DtypeWarning: Columns (8,10,14,21,27,29,30,33,35) have mixed types. Specify dtype option on import or set low_memory=False.\n",
-      "  df = pd.read_csv(StringIO(response.text), delimiter=\",\")\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/clean.py:356: FutureWarning: Logical ops (and, or, xor) between Pandas objects and dtype-less sequences (e.g. list, tuple) are deprecated and will raise in a future version. Wrap the object in a Series, Index, or np.array before operating instead.\n",
       "  cond_notna = mask & (df_out[\"QA_flag\"].notna())  # Mask cond and not NA\n",
       "/opt/hostedtoolcache/Python/3.9.25/x64/lib/python3.9/site-packages/harmonize_wq/clean.py:360: FutureWarning: Logical ops (and, or, xor) between Pandas objects and dtype-less sequences (e.g. list, tuple) are deprecated and will raise in a future version. Wrap the object in a Series, Index, or np.array before operating instead.\n",
@@ -1791,10 +1786,10 @@
    "execution_count": 12,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:48:46.966892Z",
-     "iopub.status.busy": "2026-04-05T04:48:46.966686Z",
-     "iopub.status.idle": "2026-04-05T04:48:48.402356Z",
-     "shell.execute_reply": "2026-04-05T04:48:48.401434Z"
+     "iopub.execute_input": "2026-04-15T17:19:44.050996Z",
+     "iopub.status.busy": "2026-04-15T17:19:44.050807Z",
+     "iopub.status.idle": "2026-04-15T17:19:45.414034Z",
+     "shell.execute_reply": "2026-04-15T17:19:45.413346Z"
     },
     "hidden": true
    },
@@ -1832,10 +1827,10 @@
    "execution_count": 13,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:48:48.404899Z",
-     "iopub.status.busy": "2026-04-05T04:48:48.404603Z",
-     "iopub.status.idle": "2026-04-05T04:48:51.029893Z",
-     "shell.execute_reply": "2026-04-05T04:48:51.029169Z"
+     "iopub.execute_input": "2026-04-15T17:19:45.416180Z",
+     "iopub.status.busy": "2026-04-15T17:19:45.415857Z",
+     "iopub.status.idle": "2026-04-15T17:19:47.831862Z",
+     "shell.execute_reply": "2026-04-15T17:19:47.831262Z"
     },
     "hidden": true
    },
@@ -1881,10 +1876,10 @@
    "execution_count": 14,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:48:51.031904Z",
-     "iopub.status.busy": "2026-04-05T04:48:51.031711Z",
-     "iopub.status.idle": "2026-04-05T04:48:51.034569Z",
-     "shell.execute_reply": "2026-04-05T04:48:51.034004Z"
+     "iopub.execute_input": "2026-04-15T17:19:47.834008Z",
+     "iopub.status.busy": "2026-04-15T17:19:47.833819Z",
+     "iopub.status.idle": "2026-04-15T17:19:47.836620Z",
+     "shell.execute_reply": "2026-04-15T17:19:47.836124Z"
     }
    },
    "outputs": [],
@@ -1897,10 +1892,10 @@
    "execution_count": 15,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:48:51.036497Z",
-     "iopub.status.busy": "2026-04-05T04:48:51.036284Z",
-     "iopub.status.idle": "2026-04-05T04:48:59.174476Z",
-     "shell.execute_reply": "2026-04-05T04:48:59.173747Z"
+     "iopub.execute_input": "2026-04-15T17:19:47.838307Z",
+     "iopub.status.busy": "2026-04-15T17:19:47.838138Z",
+     "iopub.status.idle": "2026-04-15T17:19:55.676320Z",
+     "shell.execute_reply": "2026-04-15T17:19:55.675711Z"
     },
     "hidden": true
    },
@@ -1933,10 +1928,10 @@
    "execution_count": 16,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:48:59.177027Z",
-     "iopub.status.busy": "2026-04-05T04:48:59.176789Z",
-     "iopub.status.idle": "2026-04-05T04:49:15.039969Z",
-     "shell.execute_reply": "2026-04-05T04:49:15.039183Z"
+     "iopub.execute_input": "2026-04-15T17:19:55.678844Z",
+     "iopub.status.busy": "2026-04-15T17:19:55.678626Z",
+     "iopub.status.idle": "2026-04-15T17:20:09.822806Z",
+     "shell.execute_reply": "2026-04-15T17:20:09.822077Z"
     },
     "hidden": true
    },
@@ -1973,16 +1968,16 @@
        "      <th>DataLoggerLine</th>\n",
        "      <th>ResultDetectionConditionText</th>\n",
        "      <th>...</th>\n",
+       "      <th>QA_pH</th>\n",
        "      <th>QA_Turbidity</th>\n",
-       "      <th>QA_Secchi</th>\n",
-       "      <th>QA_E_coli</th>\n",
-       "      <th>QA_Chlorophyll</th>\n",
-       "      <th>QA_Nitrogen</th>\n",
-       "      <th>QA_Conductivity</th>\n",
-       "      <th>QA_Salinity</th>\n",
+       "      <th>QA_DO</th>\n",
+       "      <th>QA_Temperature</th>\n",
        "      <th>QA_TP_Phosphorus</th>\n",
        "      <th>QA_TDP_Phosphorus</th>\n",
        "      <th>QA_Other_Phosphorus</th>\n",
+       "      <th>QA_Salinity</th>\n",
+       "      <th>QA_Fecal_Coliform</th>\n",
+       "      <th>QA_Conductivity</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -2095,7 +2090,7 @@
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>...</td>\n",
-       "      <td>NaN</td>\n",
+       "      <td>ResultMeasure/MeasureUnitCode: MISSING UNITS, ...</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
@@ -2321,44 +2316,57 @@
        "1537977  STORET-100013998412.0000000000             NaN   \n",
        "1537978  STORET-100013857818.0000000000             NaN   \n",
        "\n",
-       "        ResultDetectionConditionText  ... QA_Turbidity QA_Secchi QA_E_coli  \\\n",
-       "0                                NaN  ...          NaN       NaN       NaN   \n",
-       "1                                NaN  ...          NaN       NaN       NaN   \n",
-       "2                                NaN  ...          NaN       NaN       NaN   \n",
-       "3                                NaN  ...          NaN       NaN       NaN   \n",
-       "4                                NaN  ...          NaN       NaN       NaN   \n",
-       "...                              ...  ...          ...       ...       ...   \n",
-       "1537974                          NaN  ...          NaN       NaN       NaN   \n",
-       "1537975                          NaN  ...          NaN       NaN       NaN   \n",
-       "1537976                          NaN  ...          NaN       NaN       NaN   \n",
-       "1537977                          NaN  ...          NaN       NaN       NaN   \n",
-       "1537978                          NaN  ...          NaN       NaN       NaN   \n",
+       "        ResultDetectionConditionText  ...  \\\n",
+       "0                                NaN  ...   \n",
+       "1                                NaN  ...   \n",
+       "2                                NaN  ...   \n",
+       "3                                NaN  ...   \n",
+       "4                                NaN  ...   \n",
+       "...                              ...  ...   \n",
+       "1537974                          NaN  ...   \n",
+       "1537975                          NaN  ...   \n",
+       "1537976                          NaN  ...   \n",
+       "1537977                          NaN  ...   \n",
+       "1537978                          NaN  ...   \n",
        "\n",
-       "        QA_Chlorophyll QA_Nitrogen QA_Conductivity QA_Salinity  \\\n",
-       "0                  NaN         NaN             NaN         NaN   \n",
-       "1                  NaN         NaN             NaN         NaN   \n",
-       "2                  NaN         NaN             NaN         NaN   \n",
-       "3                  NaN         NaN             NaN         NaN   \n",
-       "4                  NaN         NaN             NaN         NaN   \n",
-       "...                ...         ...             ...         ...   \n",
-       "1537974            NaN         NaN             NaN         NaN   \n",
-       "1537975            NaN         NaN             NaN         NaN   \n",
-       "1537976            NaN         NaN             NaN         NaN   \n",
-       "1537977            NaN         NaN             NaN         NaN   \n",
-       "1537978            NaN         NaN             NaN         NaN   \n",
+       "                                                     QA_pH QA_Turbidity QA_DO  \\\n",
+       "0                                                      NaN          NaN   NaN   \n",
+       "1                                                      NaN          NaN   NaN   \n",
+       "2                                                      NaN          NaN   NaN   \n",
+       "3                                                      NaN          NaN   NaN   \n",
+       "4        ResultMeasure/MeasureUnitCode: MISSING UNITS, ...          NaN   NaN   \n",
+       "...                                                    ...          ...   ...   \n",
+       "1537974                                                NaN          NaN   NaN   \n",
+       "1537975                                                NaN          NaN   NaN   \n",
+       "1537976                                                NaN          NaN   NaN   \n",
+       "1537977                                                NaN          NaN   NaN   \n",
+       "1537978                                                NaN          NaN   NaN   \n",
        "\n",
-       "        QA_TP_Phosphorus QA_TDP_Phosphorus QA_Other_Phosphorus  \n",
-       "0                    NaN               NaN                 NaN  \n",
-       "1                    NaN               NaN                 NaN  \n",
-       "2                    NaN               NaN                 NaN  \n",
-       "3                    NaN               NaN                 NaN  \n",
-       "4                    NaN               NaN                 NaN  \n",
-       "...                  ...               ...                 ...  \n",
-       "1537974              NaN               NaN                 NaN  \n",
-       "1537975              NaN               NaN                 NaN  \n",
-       "1537976              NaN               NaN                 NaN  \n",
-       "1537977              NaN               NaN                 NaN  \n",
-       "1537978              NaN               NaN                 NaN  \n",
+       "        QA_Temperature QA_TP_Phosphorus QA_TDP_Phosphorus QA_Other_Phosphorus  \\\n",
+       "0                  NaN              NaN               NaN                 NaN   \n",
+       "1                  NaN              NaN               NaN                 NaN   \n",
+       "2                  NaN              NaN               NaN                 NaN   \n",
+       "3                  NaN              NaN               NaN                 NaN   \n",
+       "4                  NaN              NaN               NaN                 NaN   \n",
+       "...                ...              ...               ...                 ...   \n",
+       "1537974            NaN              NaN               NaN                 NaN   \n",
+       "1537975            NaN              NaN               NaN                 NaN   \n",
+       "1537976            NaN              NaN               NaN                 NaN   \n",
+       "1537977            NaN              NaN               NaN                 NaN   \n",
+       "1537978            NaN              NaN               NaN                 NaN   \n",
+       "\n",
+       "        QA_Salinity QA_Fecal_Coliform QA_Conductivity  \n",
+       "0               NaN               NaN             NaN  \n",
+       "1               NaN               NaN             NaN  \n",
+       "2               NaN               NaN             NaN  \n",
+       "3               NaN               NaN             NaN  \n",
+       "4               NaN               NaN             NaN  \n",
+       "...             ...               ...             ...  \n",
+       "1537974         NaN               NaN             NaN  \n",
+       "1537975         NaN               NaN             NaN  \n",
+       "1537976         NaN               NaN             NaN  \n",
+       "1537977         NaN               NaN             NaN  \n",
+       "1537978         NaN               NaN             NaN  \n",
        "\n",
        "[1465941 rows x 113 columns]"
       ]
@@ -2379,10 +2387,10 @@
    "execution_count": 17,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:49:15.042046Z",
-     "iopub.status.busy": "2026-04-05T04:49:15.041820Z",
-     "iopub.status.idle": "2026-04-05T04:49:17.113972Z",
-     "shell.execute_reply": "2026-04-05T04:49:17.113170Z"
+     "iopub.execute_input": "2026-04-15T17:20:09.824867Z",
+     "iopub.status.busy": "2026-04-15T17:20:09.824662Z",
+     "iopub.status.idle": "2026-04-15T17:20:11.637368Z",
+     "shell.execute_reply": "2026-04-15T17:20:11.636783Z"
     },
     "hidden": true
    },
@@ -2397,10 +2405,10 @@
    "execution_count": 18,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:49:17.116468Z",
-     "iopub.status.busy": "2026-04-05T04:49:17.116221Z",
-     "iopub.status.idle": "2026-04-05T04:49:18.435566Z",
-     "shell.execute_reply": "2026-04-05T04:49:18.434825Z"
+     "iopub.execute_input": "2026-04-15T17:20:11.639662Z",
+     "iopub.status.busy": "2026-04-15T17:20:11.639453Z",
+     "iopub.status.idle": "2026-04-15T17:20:12.993085Z",
+     "shell.execute_reply": "2026-04-15T17:20:12.992331Z"
     },
     "hidden": true
    },
@@ -2424,10 +2432,10 @@
    "execution_count": 19,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-05T04:49:18.437917Z",
-     "iopub.status.busy": "2026-04-05T04:49:18.437684Z",
-     "iopub.status.idle": "2026-04-05T04:51:18.281698Z",
-     "shell.execute_reply": "2026-04-05T04:51:18.280987Z"
+     "iopub.execute_input": "2026-04-15T17:20:12.995494Z",
+     "iopub.status.busy": "2026-04-15T17:20:12.995272Z",
+     "iopub.status.idle": "2026-04-15T17:22:01.969065Z",
+     "shell.execute_reply": "2026-04-15T17:22:01.968476Z"
     },
     "hidden": true
    },

--- a/harmonize_wq/wq_data.py
+++ b/harmonize_wq/wq_data.py
@@ -490,7 +490,10 @@ class WQCharData:
                     self.df[c_mask], basis_dict, self.col.unit_out
                 )
             except KeyError:
-                pass
+                warn(
+                    f"No unit-basis mapping found for out_col '{self.out_col}'; "
+                    "skipping basis_from_unit and using default/fallback basis values."
+                )
             # Finish by filling any NAs with char_val based default
             col = self.col.basis
 


### PR DESCRIPTION
To fix this without changing functionality, keep handling `KeyError` as non-fatal but replace the empty `pass` with an explicit explanatory action. The best minimal fix is to emit a warning in the `except KeyError:` block indicating unit-based basis mapping is unavailable for the current `out_col`, and that processing will continue with the existing fallback logic.

In `harmonize_wq/wq_data.py`, in the `Basis from unit` section (around lines 487–493), replace:

- `except KeyError:`
- `    pass`

with:

- `except KeyError:`
- `    warn("...")`

No new imports are needed because `warn` is already imported at line 5 (`from warnings import warn`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._