### PR TITLE
Decrease segment length for location queries

### DIFF
--- a/harmonize_wq/wrangle.py
+++ b/harmonize_wq/wrangle.py
@@ -267,7 +267,7 @@ def get_activities_by_loc(characteristic_names, locations):
     See :func:`wrangle.add_activities_to_df`
     """
     # Split loc_list as query by list may cause the query url to be too long
-    seg = 200  # Max length of each segment
+    seg = 100  # Max length of each segment
     activities_list, md_list = [], []
     for loc_que in [locations[x : x + seg] for x in range(0, len(locations), seg)]:
         query = {"characteristicName": characteristic_names, "siteid": loc_que}


### PR DESCRIPTION
Reduce maximum segment length for location queries from 200 to 100. Current string was too long, can't switch get -> post (dataretrieval package test failures with that change). The location codes (e.g., B21FLTPA_WQX-27483438243412) being ~25 is already 2500 (vs 5000).