### PR TITLE
Fix IndexError in check_precision on whole-number and missing values

### DIFF
--- a/harmonize_wq/clean.py
+++ b/harmonize_wq/clean.py
@@ -4,7 +4,7 @@
 # from warnings import warn
 from dataretrieval.codes import tz
 from numpy import nan
-from pandas import Series, to_datetime
+from pandas import Series, isna, to_datetime
 
 from harmonize_wq.convert import convert_unit_series
 from harmonize_wq.domains import accepted_methods
@@ -213,8 +213,19 @@ def check_precision(df_in, col, limit=3):
 
     """
     df_out = df_in.copy()
-    # Create T/F mask based on len of everything after the decimal
-    c_mask = Series(len(str(x).split(".")[1]) < limit for x in df_out[col])
+
+    def decimal_places(x):
+        # Digits after the decimal point. Whole numbers (and any value with
+        # no decimal point, e.g. an integer or string coordinate) have 0.
+        text = str(x)
+        return len(text.split(".")[1]) if "." in text else 0
+
+    # Create T/F mask based on len of everything after the decimal. Missing
+    # values are skipped: a blank measurement is not a precision issue and
+    # str(NaN) has no decimal point, which previously raised IndexError.
+    c_mask = Series(
+        (not isna(x)) and decimal_places(x) < limit for x in df_out[col]
+    )
     flag = f"{col}: Imprecise: lessthan{limit}decimaldigits"
     df_out = add_qa_flag(df_out, c_mask, flag)  # Assign flags
     return df_out

--- a/harmonize_wq/clean.py
+++ b/harmonize_wq/clean.py
@@ -223,9 +223,7 @@ def check_precision(df_in, col, limit=3):
     # Create T/F mask based on len of everything after the decimal. Missing
     # values are skipped: a blank measurement is not a precision issue and
     # str(NaN) has no decimal point, which previously raised IndexError.
-    c_mask = Series(
-        (not isna(x)) and decimal_places(x) < limit for x in df_out[col]
-    )
+    c_mask = Series((not isna(x)) and decimal_places(x) < limit for x in df_out[col])
     flag = f"{col}: Imprecise: lessthan{limit}decimaldigits"
     df_out = add_qa_flag(df_out, c_mask, flag)  # Assign flags
     return df_out

--- a/harmonize_wq/tests/test_harmonize_WQP.py
+++ b/harmonize_wq/tests/test_harmonize_WQP.py
@@ -237,6 +237,29 @@ def test_harmonize_locations():
     return actual
 
 
+def test_check_precision():
+    """Test check_precision flags low-precision values without crashing.
+
+    Values with no decimal point (whole numbers, or a missing/NaN coordinate)
+    used to raise IndexError because str(x).split('.')[1] has no second element.
+    """
+    df = pandas.DataFrame(
+        {
+            "LatitudeMeasure": [27.595036, 45, float("nan")],
+            "QA_flag": [None, None, None],
+        }
+    )
+    out = clean.check_precision(df, "LatitudeMeasure")
+
+    flag = "LatitudeMeasure: Imprecise: lessthan3decimaldigits"
+    # Six decimal places: precise, not flagged
+    assert pandas.isna(out.iloc[0]["QA_flag"])
+    # Whole number: fewer than three decimals, flagged as imprecise
+    assert out.iloc[1]["QA_flag"] == flag
+    # Missing value: not a precision issue, not flagged (and no crash)
+    assert pandas.isna(out.iloc[2]["QA_flag"])
+
+
 # @pytest.mark.skip(reason="no change")
 def test_harmonize_phosphorus(merged_tables):
     """


### PR DESCRIPTION
check_precision counts decimal digits with str(x).split(".")[1]. That has no second element when a value has no decimal point, so it raises IndexError. It happens for whole-number coordinates (an integer-typed column, or a string like "45") and for missing values, since str(NaN) is "nan".

harmonize_locations runs this check on LatitudeMeasure and LongitudeMeasure before any missing-value handling, so one blank coordinate aborts the whole call:

    IndexError: list index out of range

Repro:

    from harmonize_wq import clean
    import pandas
    df = pandas.DataFrame({"LatitudeMeasure": [45, float("nan")], "QA_flag": [None, None]})
    clean.check_precision(df, "LatitudeMeasure")  # raises

The fix counts decimal places without assuming a decimal point is present (no point means zero decimals) and skips missing values, which are a missing-data problem rather than a precision one. A whole number still gets flagged as imprecise, which matches the intent of the check.

Added a test in test_harmonize_WQP.py covering a precise value, a whole number, and a missing value. It fails on the current code with the IndexError above and passes with the fix. The existing test_harmonize_locations assertions (row 302 precision flag, output size) are unchanged.