### PR TITLE
Test the mask argument against None, not for truth

### DIFF
--- a/harmonize_wq/clean.py
+++ b/harmonize_wq/clean.py
@@ -307,7 +307,7 @@ def wet_dry_checks(df_in, mask=None):
         & (df_out["ActivityMediaName"] == "Water")
     )
     # Use mask if user specified, else run on all rows
-    if mask:
+    if mask is not None:
         media_mask = mask & (media_mask)
     # Assign QA flag where data was bad
     df_out = add_qa_flag(df_out, media_mask, qa_flag)

--- a/harmonize_wq/tests/test_harmonize_WQP.py
+++ b/harmonize_wq/tests/test_harmonize_WQP.py
@@ -1407,3 +1407,45 @@ def test_print_report(test_harmonize_temperature, capsys):
     expected += "Usable results with inferred units: 0\n"
     expected += "Results outside threshold (0.0 to 884.229584): 4\n"
     assert captured == expected
+
+
+def test_wet_dry_checks_accepts_a_mask():
+    """Test wet_dry_checks with the documented mask argument.
+
+    mask is documented as a pandas.Series, but the guard tested it for truth
+    rather than for None, so any Series raised "The truth value of a Series is
+    ambiguous".
+    """
+    df = pandas.DataFrame(
+        {
+            "ActivityMediaName": ["Water", "Water", "Sediment"],
+            "ResultSampleFractionText": ["Bed Sediment", "Total", "Bed Sediment"],
+            "ResultWeightBasisText": ["Dry", "Wet", "Dry"],
+        }
+    )
+    mask = df["ActivityMediaName"] == "Water"
+
+    out = clean.wet_dry_checks(df, mask=mask)
+
+    # Row 0 is Water reported as dry bed sediment, so it is corrected.
+    assert list(out["ActivityMediaName"]) == ["Sediment", "Water", "Sediment"]
+    # The same call without a mask reaches the same answer here.
+    assert list(clean.wet_dry_checks(df)["ActivityMediaName"]) == list(
+        out["ActivityMediaName"]
+    )
+
+
+def test_wet_dry_checks_mask_limits_rows():
+    """Test that a mask excluding a row leaves that row alone."""
+    df = pandas.DataFrame(
+        {
+            "ActivityMediaName": ["Water", "Water"],
+            "ResultSampleFractionText": ["Bed Sediment", "Bed Sediment"],
+            "ResultWeightBasisText": ["Dry", "Dry"],
+        }
+    )
+    mask = pandas.Series([True, False])
+
+    out = clean.wet_dry_checks(df, mask=mask)
+
+    assert list(out["ActivityMediaName"]) == ["Sediment", "Water"]

--- a/harmonize_wq/wrangle.py
+++ b/harmonize_wq/wrangle.py
@@ -373,7 +373,7 @@ def add_activities_to_df(df_in, mask=None):
     loc_col = "MonitoringLocationIdentifier"
     df_checks(df_out, [loc_col])
     # List of unique sites and characteristicNames
-    if mask:
+    if mask is not None:
         loc_list = list(set(df_out.loc[mask, loc_col].dropna()))
         char_vals = list(set(df_out.loc[mask, "CharacteristicName"].dropna()))
     else:


### PR DESCRIPTION
`wet_dry_checks` and `add_activities_to_df` both accept `mask=None` and document it as

```
mask : pandas.Series
    Row conditional (bool) mask
```

but branch on it with a bare truth test:

```python
if mask:
```

A Series has no truth value, so passing the documented type raises:

```
>>> clean.wet_dry_checks(df, mask=df["ActivityMediaName"] == "Water")
ValueError: The truth value of a Series is ambiguous. Use a.empty, a.bool(), a.item(), a.any() or a.all().
```

Every documented use of the argument fails. It went unnoticed because the only in-tree caller, `wet_dry_drop` at `clean.py:420`, passes no mask, so the branch is never taken with a real value.

`wq_data.py` already writes this correctly in four places (`if mask is None:` at lines 247, 728, 783, 835), so this looks like an inconsistency rather than an intentional shape. Both sites now use `is not None`.

`wrangle.py:376` in `add_activities_to_df` has the identical defect and is fixed in the same change. It fires before that function's network call, so it is reachable without any WQP request.

Two tests added next to `test_check_precision`, which was itself added for an analogous crash. One asserts a mask produces the same corrections as the no-mask call on the same frame, and one asserts a mask that excludes a row leaves that row untouched, so the argument is checked for effect and not just for absence of an exception. Both fail without the change with the ValueError above.
